### PR TITLE
DRAFT: Fixups for rust-server hyper1 support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -371,6 +371,16 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
     }
 
     @Override
+    public String toParamName(String name) {
+        // rust-server doesn't support r# in param name.
+        if (parameterNameMapping.containsKey(name)) {
+            return parameterNameMapping.get(name);
+        }
+
+        return sanitizeIdentifier(name, CasingType.SNAKE_CASE, "param", "parameter", false);
+    }
+
+    @Override
     public String toEnumValue(String value, String datatype) {
         // rust-server templates expect value to be in quotes
         return "\"" + super.toEnumValue(value, datatype) + "\"";
@@ -1229,6 +1239,9 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
                 && (mdl.dataType.startsWith("swagger::OneOf") || mdl.dataType.startsWith("swagger::AnyOf"))) {
             toStringSupport = false;
             partialOrdSupport = false;
+        } else if (mdl.dataType != null && mdl.dataType.equals("serde_json::Value")) {
+            // Value doesn't implement PartialOrd
+            partialOrdSupport = false;
         } else if (mdl.getAdditionalPropertiesType() != null) {
             toStringSupport = false;
         } else if (model instanceof ComposedSchema) {
@@ -1545,7 +1558,18 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             }
         } else {
             param.vendorExtensions.put("x-format-string", "{:?}");
-            if (param.example != null) {
+            // Check if this is a model-type enum (allowableValues with values list)
+            if (param.allowableValues != null && param.allowableValues.containsKey("values")) {
+                List<?> values = (List<?>) param.allowableValues.get("values");
+                if (!values.isEmpty()) {
+                    // Use the first enum value as the example.
+                    String firstEnumValue = values.get(0).toString();
+                    String enumVariant = toEnumVarName(firstEnumValue, param.dataType);
+                    example = param.dataType + "::" + enumVariant;
+                } else if (param.example != null) {
+                    example = "serde_json::from_str::<" + param.dataType + ">(r#\"" + param.example + "\"#).expect(\"Failed to parse JSON example\")";
+                }
+            } else if (param.example != null) {
                 example = "serde_json::from_str::<" + param.dataType + ">(r#\"" + param.example + "\"#).expect(\"Failed to parse JSON example\")";
             }
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegenDeprecated.java
@@ -1229,6 +1229,9 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
                 && (mdl.dataType.startsWith("swagger::OneOf") || mdl.dataType.startsWith("swagger::AnyOf"))) {
             toStringSupport = false;
             partialOrdSupport = false;
+        } else if (mdl.dataType != null && mdl.dataType.equals("serde_json::Value")) {
+            // Value doesn't implement PartialOrd
+            partialOrdSupport = false;
         } else if (mdl.getAdditionalPropertiesType() != null) {
             toStringSupport = false;
         } else if (model instanceof ComposedSchema) {
@@ -1546,7 +1549,18 @@ public class RustServerCodegenDeprecated extends AbstractRustCodegen implements 
         }
             else {
             param.vendorExtensions.put("x-format-string", "{:?}");
-            if (param.example != null) {
+            // Check if this is a model-type enum (allowableValues with values list)
+            if (param.allowableValues != null && param.allowableValues.containsKey("values")) {
+                List<?> values = (List<?>) param.allowableValues.get("values");
+                if (!values.isEmpty()) {
+                    // Use the first enum value as the example.
+                    String firstEnumValue = values.get(0).toString();
+                    String enumVariant = toEnumVarName(firstEnumValue, param.dataType);
+                    example = param.dataType + "::" + enumVariant;
+                } else if (param.example != null) {
+                    example = "serde_json::from_str::<" + param.dataType + ">(r#\"" + param.example + "\"#).expect(\"Failed to parse JSON example\")";
+                }
+            } else if (param.example != null) {
                 example = "serde_json::from_str::<" + param.dataType + ">(r#\"" + param.example + "\"#).expect(\"Failed to parse JSON example\")";
             }
         }

--- a/modules/openapi-generator/src/main/resources/rust-server/client-request-body-instance.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/client-request-body-instance.mustache
@@ -80,12 +80,17 @@
       {{/required}}
       {{#exts}}
         {{#x-consumes-plain-text}}
-          {{#isByteArray}}
-        let body = String::from_utf8(param_body.0).expect("Body was not valid UTF8");
-          {{/isByteArray}}
-          {{^isByteArray}}
+        {{^isByteArray}}
+        {{^isBinary}}
         let body = param_{{{paramName}}};
-          {{/isByteArray}}
+        {{/isBinary}}
+        {{/isByteArray}}
+        {{#isByteArray}}
+        let body = String::from_utf8(param_{{{paramName}}}.0).expect("Body was not valid UTF8");
+        {{/isByteArray}}
+        {{#isBinary}}
+        let body = String::from_utf8(param_{{{paramName}}}.0).expect("Body was not valid UTF8");
+        {{/isBinary}}
         {{/x-consumes-plain-text}}
         {{#x-consumes-xml}}
         let body = param_{{{paramName}}}.as_xml();

--- a/modules/openapi-generator/src/main/resources/rust-server/server-request-body-basic.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-request-body-basic.mustache
@@ -28,6 +28,9 @@
 
           {{/x-consumes-plain-text}}
           {{#x-consumes-plain-text}}
+            {{#isBinary}}
+                                    Some(swagger::ByteArray(body.to_vec()))
+            {{/isBinary}}
             {{#isByteArray}}
                                     Some(swagger::ByteArray(body.to_vec()))
             {{/isByteArray}}

--- a/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/rust-server/openapi-v3.yaml
@@ -500,6 +500,7 @@ paths:
       summary: Test a Form Post
       operationId: FormTest
       requestBody:
+        required: true
         content:
           application/x-www-form-urlencoded:
             schema:
@@ -509,7 +510,13 @@ paths:
                   type: array
                   items:
                     type: string
-        required: true
+                enum_field:
+                  type: string
+                  enum:
+                    - one_enum
+              required:
+                - requiredArray
+                - enum_field
       responses:
         '200':
           description: OK
@@ -728,6 +735,9 @@ components:
     NullableObject:
       type: string
       nullable: true
+    NoTypeObject:
+      title: an object with no type
+      description: An object with no type
     NullableTest:
       type: object
       required:

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/.openapi-generator/FILES
@@ -19,11 +19,13 @@ docs/DuplicateXmlObject.md
 docs/EnumWithStarObject.md
 docs/Err.md
 docs/Error.md
+docs/FormTestRequestEnumField.md
 docs/Model12345AnyOfObject.md
 docs/Model12345AnyOfObjectAnyOf.md
 docs/MultigetGet201Response.md
 docs/MyId.md
 docs/MyIdList.md
+docs/NoTypeObject.md
 docs/NullableObject.md
 docs/NullableTest.md
 docs/ObjectHeader.md

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/README.md
@@ -113,6 +113,7 @@ cargo run --example client XmlOtherPost
 cargo run --example client XmlOtherPut
 cargo run --example client XmlPost
 cargo run --example client XmlPut
+cargo run --example client EnumInPathPathParamGet
 cargo run --example client MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet
 cargo run --example client CreateRepo
 cargo run --example client GetRepoInfo
@@ -201,11 +202,13 @@ Method | HTTP request | Description
  - [EnumWithStarObject](docs/EnumWithStarObject.md)
  - [Err](docs/Err.md)
  - [Error](docs/Error.md)
+ - [FormTestRequestEnumField](docs/FormTestRequestEnumField.md)
  - [Model12345AnyOfObject](docs/Model12345AnyOfObject.md)
  - [Model12345AnyOfObjectAnyOf](docs/Model12345AnyOfObjectAnyOf.md)
  - [MultigetGet201Response](docs/MultigetGet201Response.md)
  - [MyId](docs/MyId.md)
  - [MyIdList](docs/MyIdList.md)
+ - [NoTypeObject](docs/NoTypeObject.md)
  - [NullableObject](docs/NullableObject.md)
  - [NullableTest](docs/NullableTest.md)
  - [ObjectHeader](docs/ObjectHeader.md)

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/api/openapi.yaml
@@ -780,6 +780,9 @@ components:
     NullableObject:
       nullable: true
       type: string
+    NoTypeObject:
+      description: An object with no type
+      title: an object with no type
     NullableTest:
       properties:
         nullable:
@@ -847,12 +850,21 @@ components:
       anyOf:
       - $ref: "#/components/schemas/StringObject"
       - $ref: "#/components/schemas/UuidObject"
+    FormTest_request_enum_field:
+      enum:
+      - one_enum
+      type: string
     FormTest_request:
       properties:
         requiredArray:
           items:
             type: string
           type: array
+        enum_field:
+          $ref: "#/components/schemas/FormTest_request_enum_field"
+      required:
+      - enum_field
+      - requiredArray
       type: object
     AnyOfObject_anyOf:
       enum:

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/bin/cli.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/bin/cli.rs
@@ -112,7 +112,9 @@ enum Operation {
     /// Test a Form Post
     FormTest {
         #[structopt(parse(try_from_str = parse_json), long)]
-        required_array: Option<Vec<String>>,
+        required_array: Vec<String>,
+        #[structopt(parse(try_from_str = parse_json))]
+        enum_field: models::FormTestRequestEnumField,
     },
     GetWithBooleanParameter {
         /// Let's check apostrophes get encoded properly!
@@ -352,11 +354,13 @@ async fn main() -> Result<()> {
         }
         Operation::FormTest {
             required_array,
+            enum_field,
         } => {
             info!("Performing a FormTest request");
 
             let result = client.form_test(
                 required_array.as_ref(),
+                enum_field,
             ).await?;
             debug!("Result: {:?}", result);
 

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/FormTestRequestEnumField.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/FormTestRequestEnumField.md
@@ -1,0 +1,9 @@
+# FormTestRequestEnumField
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/FormTestRequestGrantType.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/FormTestRequestGrantType.md
@@ -1,0 +1,9 @@
+# FormTestRequestGrantType
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/NoTypeObject.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/NoTypeObject.md
@@ -1,0 +1,9 @@
+# NoTypeObject
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/docs/default_api.md
@@ -159,21 +159,15 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **FormTest**
-> FormTest(optional)
+> FormTest(required_array, enum_field)
 Test a Form Post
 
 ### Required Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **required_array** | [**String**](String.md)|  | 
+  **required_array** | [**String**](String.md)|  | 
+  **enum_field** | [**FormTest_request_enum_field**](FormTest_request_enum_field.md)|  | 
 
 ### Return type
 

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/client/main.rs
@@ -92,6 +92,7 @@ fn main() {
                 "XmlOtherPut",
                 "XmlPost",
                 "XmlPut",
+                "EnumInPathPathParamGet",
                 "MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet",
                 "CreateRepo",
                 "GetRepoInfo",
@@ -197,7 +198,8 @@ fn main() {
         },
         Some("FormTest") => {
             let result = rt.block_on(client.form_test(
-                  Some(&Vec::new())
+                  &Vec::new(),
+                  models::FormTestRequestEnumField::OneEnum
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
@@ -327,14 +329,12 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        /* Disabled because there's no example.
         Some("EnumInPathPathParamGet") => {
             let result = rt.block_on(client.enum_in_path_path_param_get(
-                  ???
+                  models::StringEnum::Foo
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        */
         Some("MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet") => {
             let result = rt.block_on(client.multiple_path_params_with_very_long_path_to_test_formatting_path_param_a_path_param_b_get(
                   "path_param_a_example".to_string(),

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/examples/server/server.rs
@@ -177,10 +177,11 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>
     {
-        info!("form_test({:?}) - X-Span-ID: {:?}", required_array, context.get().0.clone());
+        info!("form_test({:?}, {:?}) - X-Span-ID: {:?}", required_array, enum_field, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
     async fn get_with_boolean_parameter(

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/client/mod.rs
@@ -744,7 +744,8 @@ impl<S, C> Api<C> for Client<S, C> where
     }
     async fn form_test(
         &self,
-        param_required_array: Option<&Vec<String>>,
+        param_required_array: &Vec<String>,
+        param_enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -779,7 +780,6 @@ impl<S, C> Api<C> for Client<S, C> where
 
         // Consumes form body
         let mut params = vec![];
-        if let Some(param_required_array) = param_required_array {
         // style=form,explode=true
         for param_required_array in param_required_array {
         #[allow(clippy::uninlined_format_args)]
@@ -787,7 +787,10 @@ impl<S, C> Api<C> for Client<S, C> where
             format!("{:?}", param_required_array)
         ));
         }
-        }
+        #[allow(clippy::uninlined_format_args)]
+        params.push(("enum_field",
+            format!("{:?}", param_enum_field)
+        ));
 
         let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
 

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/lib.rs
@@ -310,7 +310,8 @@ pub trait Api<C: Send + Sync> {
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>;
 
     async fn get_with_boolean_parameter(
@@ -476,7 +477,8 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         ) -> Result<FormTestResponse, ApiError>;
 
     async fn get_with_boolean_parameter(
@@ -672,11 +674,12 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         ) -> Result<FormTestResponse, ApiError>
     {
         let context = self.context().clone();
-        self.api().form_test(required_array, &context).await
+        self.api().form_test(required_array, enum_field, &context).await
     }
 
     async fn get_with_boolean_parameter(

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/models.rs
@@ -2252,6 +2252,124 @@ impl Error {
     }
 }
 
+/// Enumeration of values.
+/// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
+/// which helps with FFI.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
+pub enum FormTestRequestEnumField {
+    #[serde(rename = "one_enum")]
+    OneEnum,
+}
+
+impl std::fmt::Display for FormTestRequestEnumField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            FormTestRequestEnumField::OneEnum => write!(f, "one_enum"),
+        }
+    }
+}
+
+impl std::str::FromStr for FormTestRequestEnumField {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "one_enum" => std::result::Result::Ok(FormTestRequestEnumField::OneEnum),
+            _ => std::result::Result::Err(format!("Value not valid: {s}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<FormTestRequestEnumField> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<FormTestRequestEnumField>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<FormTestRequestEnumField>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FormTestRequestEnumField - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<FormTestRequestEnumField> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <FormTestRequestEnumField as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into FormTestRequestEnumField - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<FormTestRequestEnumField>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<FormTestRequestEnumField>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<FormTestRequestEnumField>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<FormTestRequestEnumField> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <FormTestRequestEnumField as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into FormTestRequestEnumField - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}
+
+impl FormTestRequestEnumField {
+    /// Helper function to allow us to convert this model to an XML string.
+    /// Will panic if serialisation fails.
+    #[allow(dead_code)]
+    pub(crate) fn as_xml(&self) -> String {
+        serde_xml_rs::to_string(&self).expect("impossible to fail to serialize")
+    }
+}
+
 /// Test a model containing an anyOf that starts with a number
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2994,6 +3112,146 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 }
 
 impl MyIdList {
+    /// Helper function to allow us to convert this model to an XML string.
+    /// Will panic if serialisation fails.
+    #[allow(dead_code)]
+    pub(crate) fn as_xml(&self) -> String {
+        serde_xml_rs::to_string(&self).expect("impossible to fail to serialize")
+    }
+}
+
+/// An object with no type
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct NoTypeObject(serde_json::Value);
+
+impl std::convert::From<serde_json::Value> for NoTypeObject {
+    fn from(x: serde_json::Value) -> Self {
+        NoTypeObject(x)
+    }
+}
+
+impl std::convert::From<NoTypeObject> for serde_json::Value {
+    fn from(x: NoTypeObject) -> Self {
+        x.0
+    }
+}
+
+impl std::ops::Deref for NoTypeObject {
+    type Target = serde_json::Value;
+    fn deref(&self) -> &serde_json::Value {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for NoTypeObject {
+    fn deref_mut(&mut self) -> &mut serde_json::Value {
+        &mut self.0
+    }
+}
+
+/// Converts the NoTypeObject value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl ::std::string::ToString for NoTypeObject {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a NoTypeObject value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl ::std::str::FromStr for NoTypeObject {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match std::str::FromStr::from_str(s) {
+             std::result::Result::Ok(r) => std::result::Result::Ok(NoTypeObject(r)),
+             std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {s} to NoTypeObject: {e:?}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<NoTypeObject> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<NoTypeObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<NoTypeObject>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for NoTypeObject - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NoTypeObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <NoTypeObject as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into NoTypeObject - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<NoTypeObject>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<NoTypeObject>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<NoTypeObject>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<NoTypeObject> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <NoTypeObject as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into NoTypeObject - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}
+
+impl NoTypeObject {
     /// Helper function to allow us to convert this model to an XML string.
     /// Will panic if serialisation fails.
     #[allow(dead_code)]

--- a/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/openapi-v3/src/server/mod.rs
@@ -473,9 +473,12 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                      Ok(body) => {
                                 // Form parameters
                                 let param_required_array =
-                                    None;
+                                    Vec::new();
+                                let param_enum_field =
+                                    models::FormTestRequestEnumField::OneEnum;
                                 let result = api_impl.form_test(
                                             param_required_array.as_ref(),
+                                            param_enum_field,
                                         &context
                                     ).await;
                                 let mut response = Response::new(Body::empty());

--- a/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -245,12 +245,12 @@ fn main() {
         Some("TestEnumParameters") => {
             let result = rt.block_on(client.test_enum_parameters(
                   Some(&Vec::new()),
-                  None,
+                  Some(models::TestEnumParametersEnumHeaderStringParameter::Abc),
                   Some(&Vec::new()),
-                  None,
-                  None,
-                  None,
-                  None
+                  Some(models::TestEnumParametersEnumHeaderStringParameter::Abc),
+                  Some(models::TestEnumParametersEnumQueryIntegerParameter::Variant1),
+                  Some(models::TestEnumParametersEnumQueryDoubleParameter::Variant11),
+                  Some(models::TestEnumParametersRequestEnumFormString::Abc)
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },

--- a/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -1073,7 +1073,7 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                      Ok(body) => {
                                 // Form parameters
                                 let param_enum_form_string =
-                                    None;
+                                    Some(models::TestEnumParametersRequestEnumFormString::Abc);
                                 let result = api_impl.test_enum_parameters(
                                             param_enum_header_string_array.as_ref(),
                                             param_enum_header_string,

--- a/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator-ignore
+++ b/samples/server/petstore/rust-server/output/multipart-v3/.openapi-generator-ignore
@@ -21,5 +21,3 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
-#
-#

--- a/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/openapi-v3/.openapi-generator/FILES
@@ -19,11 +19,13 @@ docs/DuplicateXmlObject.md
 docs/EnumWithStarObject.md
 docs/Err.md
 docs/Error.md
+docs/FormTestRequestEnumField.md
 docs/Model12345AnyOfObject.md
 docs/Model12345AnyOfObjectAnyOf.md
 docs/MultigetGet201Response.md
 docs/MyId.md
 docs/MyIdList.md
+docs/NoTypeObject.md
 docs/NullableObject.md
 docs/NullableTest.md
 docs/ObjectHeader.md

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -113,6 +113,7 @@ cargo run --example client XmlOtherPost
 cargo run --example client XmlOtherPut
 cargo run --example client XmlPost
 cargo run --example client XmlPut
+cargo run --example client EnumInPathPathParamGet
 cargo run --example client MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet
 cargo run --example client CreateRepo
 cargo run --example client GetRepoInfo
@@ -201,11 +202,13 @@ Method | HTTP request | Description
  - [EnumWithStarObject](docs/EnumWithStarObject.md)
  - [Err](docs/Err.md)
  - [Error](docs/Error.md)
+ - [FormTestRequestEnumField](docs/FormTestRequestEnumField.md)
  - [Model12345AnyOfObject](docs/Model12345AnyOfObject.md)
  - [Model12345AnyOfObjectAnyOf](docs/Model12345AnyOfObjectAnyOf.md)
  - [MultigetGet201Response](docs/MultigetGet201Response.md)
  - [MyId](docs/MyId.md)
  - [MyIdList](docs/MyIdList.md)
+ - [NoTypeObject](docs/NoTypeObject.md)
  - [NullableObject](docs/NullableObject.md)
  - [NullableTest](docs/NullableTest.md)
  - [ObjectHeader](docs/ObjectHeader.md)

--- a/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/api/openapi.yaml
@@ -780,6 +780,9 @@ components:
     NullableObject:
       nullable: true
       type: string
+    NoTypeObject:
+      description: An object with no type
+      title: an object with no type
     NullableTest:
       properties:
         nullable:
@@ -847,12 +850,21 @@ components:
       anyOf:
       - $ref: "#/components/schemas/StringObject"
       - $ref: "#/components/schemas/UuidObject"
+    FormTest_request_enum_field:
+      enum:
+      - one_enum
+      type: string
     FormTest_request:
       properties:
         requiredArray:
           items:
             type: string
           type: array
+        enum_field:
+          $ref: "#/components/schemas/FormTest_request_enum_field"
+      required:
+      - enum_field
+      - requiredArray
       type: object
     AnyOfObject_anyOf:
       enum:

--- a/samples/server/petstore/rust-server/output/openapi-v3/bin/cli.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/bin/cli.rs
@@ -112,7 +112,9 @@ enum Operation {
     /// Test a Form Post
     FormTest {
         #[clap(value_parser = parse_json::<Vec<String>>, long)]
-        required_array: Option<Vec<String>>,
+        required_array: Vec<String>,
+        #[clap(value_parser = parse_json::<models::FormTestRequestEnumField>)]
+        enum_field: models::FormTestRequestEnumField,
     },
     GetWithBooleanParameter {
         /// Let's check apostrophes get encoded properly!
@@ -352,11 +354,13 @@ async fn main() -> Result<()> {
         }
         Operation::FormTest {
             required_array,
+            enum_field,
         } => {
             info!("Performing a FormTest request");
 
             let result = client.form_test(
                 required_array.as_ref(),
+                enum_field,
             ).await?;
             debug!("Result: {:?}", result);
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/FormTestRequestEnumField.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/FormTestRequestEnumField.md
@@ -1,0 +1,9 @@
+# FormTestRequestEnumField
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/NoTypeObject.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/NoTypeObject.md
@@ -1,0 +1,9 @@
+# NoTypeObject
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/default_api.md
@@ -159,21 +159,15 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **FormTest**
-> FormTest(optional)
+> FormTest(required_array, enum_field)
 Test a Form Post
 
 ### Required Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
-
-### Optional Parameters
-Optional parameters are passed through a map[string]interface{}.
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
- **required_array** | [**String**](String.md)|  | 
+  **required_array** | [**String**](String.md)|  | 
+  **enum_field** | [**FormTest_request_enum_field**](FormTest_request_enum_field.md)|  | 
 
 ### Return type
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/main.rs
@@ -196,7 +196,8 @@ fn main() {
         },
         Some("FormTest") => {
             let result = rt.block_on(client.form_test(
-                  Some(&Vec::new())
+                  &Vec::new(),
+                  models::FormTestRequestEnumField::OneEnum
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
@@ -326,14 +327,12 @@ fn main() {
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        /* Disabled because there's no example.
         Some("EnumInPathPathParamGet") => {
             let result = rt.block_on(client.enum_in_path_path_param_get(
-                  ???
+                  models::StringEnum::Foo
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
-        */
         Some("MultiplePathParamsWithVeryLongPathToTestFormattingPathParamAPathParamBGet") => {
             let result = rt.block_on(client.multiple_path_params_with_very_long_path_to_test_formatting_path_param_a_path_param_b_get(
                   "path_param_a_example".to_string(),

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -216,10 +216,11 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>
     {
-        info!("form_test({:?}) - X-Span-ID: {:?}", required_array, context.get().0.clone());
+        info!("form_test({:?}, {:?}) - X-Span-ID: {:?}", required_array, enum_field, context.get().0.clone());
         Err(ApiError("Api-Error: Operation is NOT implemented".into()))
     }
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/mod.rs
@@ -789,7 +789,8 @@ impl<S, C, B> Api<C> for Client<S, C> where
     #[allow(clippy::vec_init_then_push)]
     async fn form_test(
         &self,
-        param_required_array: Option<&Vec<String>>,
+        param_required_array: &Vec<String>,
+        param_enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>
     {
         let mut client_service = self.client_service.clone();
@@ -824,7 +825,6 @@ impl<S, C, B> Api<C> for Client<S, C> where
 
         // Consumes form body
         let mut params = vec![];
-        if let Some(param_required_array) = param_required_array {
         // style=form,explode=true
         for param_required_array in param_required_array {
         #[allow(clippy::uninlined_format_args)]
@@ -832,7 +832,10 @@ impl<S, C, B> Api<C> for Client<S, C> where
             format!("{:?}", param_required_array)
         ));
         }
-        }
+        #[allow(clippy::uninlined_format_args)]
+        params.push(("enum_field",
+            format!("{:?}", param_enum_field)
+        ));
 
         let body = serde_urlencoded::to_string(params).expect("impossible to fail to serialize");
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -337,7 +337,8 @@ pub trait Api<C: Send + Sync> {
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         context: &C) -> Result<FormTestResponse, ApiError>;
 
     async fn get_with_boolean_parameter(
@@ -501,7 +502,8 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         ) -> Result<FormTestResponse, ApiError>;
 
     async fn get_with_boolean_parameter(
@@ -693,11 +695,12 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     /// Test a Form Post
     async fn form_test(
         &self,
-        required_array: Option<&Vec<String>>,
+        required_array: &Vec<String>,
+        enum_field: models::FormTestRequestEnumField,
         ) -> Result<FormTestResponse, ApiError>
     {
         let context = self.context().clone();
-        self.api().form_test(required_array, &context).await
+        self.api().form_test(required_array, enum_field, &context).await
     }
 
     async fn get_with_boolean_parameter(

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -2252,6 +2252,124 @@ impl Error {
     }
 }
 
+/// Enumeration of values.
+/// Since this enum's variants do not hold data, we can easily define them as `#[repr(C)]`
+/// which helps with FFI.
+#[allow(non_camel_case_types)]
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
+pub enum FormTestRequestEnumField {
+    #[serde(rename = "one_enum")]
+    OneEnum,
+}
+
+impl std::fmt::Display for FormTestRequestEnumField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            FormTestRequestEnumField::OneEnum => write!(f, "one_enum"),
+        }
+    }
+}
+
+impl std::str::FromStr for FormTestRequestEnumField {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "one_enum" => std::result::Result::Ok(FormTestRequestEnumField::OneEnum),
+            _ => std::result::Result::Err(format!("Value not valid: {s}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<FormTestRequestEnumField> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<FormTestRequestEnumField>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<FormTestRequestEnumField>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for FormTestRequestEnumField - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<FormTestRequestEnumField> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <FormTestRequestEnumField as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into FormTestRequestEnumField - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<FormTestRequestEnumField>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<FormTestRequestEnumField>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}",))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<FormTestRequestEnumField>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<FormTestRequestEnumField> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <FormTestRequestEnumField as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into FormTestRequestEnumField - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}
+
+impl FormTestRequestEnumField {
+    /// Helper function to allow us to convert this model to an XML string.
+    /// Will panic if serialisation fails.
+    #[allow(dead_code)]
+    pub(crate) fn as_xml(&self) -> String {
+        serde_xml_rs::to_string(&self).expect("impossible to fail to serialize")
+    }
+}
+
 /// Test a model containing an anyOf that starts with a number
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -2994,6 +3112,146 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 }
 
 impl MyIdList {
+    /// Helper function to allow us to convert this model to an XML string.
+    /// Will panic if serialisation fails.
+    #[allow(dead_code)]
+    pub(crate) fn as_xml(&self) -> String {
+        serde_xml_rs::to_string(&self).expect("impossible to fail to serialize")
+    }
+}
+
+/// An object with no type
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct NoTypeObject(serde_json::Value);
+
+impl std::convert::From<serde_json::Value> for NoTypeObject {
+    fn from(x: serde_json::Value) -> Self {
+        NoTypeObject(x)
+    }
+}
+
+impl std::convert::From<NoTypeObject> for serde_json::Value {
+    fn from(x: NoTypeObject) -> Self {
+        x.0
+    }
+}
+
+impl std::ops::Deref for NoTypeObject {
+    type Target = serde_json::Value;
+    fn deref(&self) -> &serde_json::Value {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for NoTypeObject {
+    fn deref_mut(&mut self) -> &mut serde_json::Value {
+        &mut self.0
+    }
+}
+
+/// Converts the NoTypeObject value to the Query Parameters representation (style=form, explode=false)
+/// specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for NoTypeObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a NoTypeObject value
+/// as specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde deserializer
+impl ::std::str::FromStr for NoTypeObject {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match std::str::FromStr::from_str(s) {
+             std::result::Result::Ok(r) => std::result::Result::Ok(NoTypeObject(r)),
+             std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {s} to NoTypeObject: {e:?}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<NoTypeObject> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<NoTypeObject>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<NoTypeObject>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for NoTypeObject - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NoTypeObject> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <NoTypeObject as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into NoTypeObject - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<NoTypeObject>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<NoTypeObject>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}",))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<NoTypeObject>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<NoTypeObject> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <NoTypeObject as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into NoTypeObject - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}
+
+impl NoTypeObject {
     /// Helper function to allow us to convert this model to an XML string.
     /// Will panic if serialisation fails.
     #[allow(dead_code)]

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -509,11 +509,14 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
                      Ok(body) => {
                                 // Form parameters
                                 let param_required_array =
-                                    None;
+                                    Vec::new();
+                                let param_enum_field =
+                                    models::FormTestRequestEnumField::OneEnum;
 
 
                                 let result = api_impl.form_test(
                                             param_required_array.as_ref(),
+                                            param_enum_field,
                                         &context
                                     ).await;
                                 let mut response = Response::new(BoxBody::new(http_body_util::Empty::new()));

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/client/main.rs
@@ -253,12 +253,12 @@ fn main() {
         Some("TestEnumParameters") => {
             let result = rt.block_on(client.test_enum_parameters(
                   Some(&Vec::new()),
-                  None,
+                  Some(models::TestEnumParametersEnumHeaderStringParameter::Abc),
                   Some(&Vec::new()),
-                  None,
-                  None,
-                  None,
-                  None
+                  Some(models::TestEnumParametersEnumHeaderStringParameter::Abc),
+                  Some(models::TestEnumParametersEnumQueryIntegerParameter::Variant1),
+                  Some(models::TestEnumParametersEnumQueryDoubleParameter::Variant11),
+                  Some(models::TestEnumParametersRequestEnumFormString::Abc)
             ));
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -1132,7 +1132,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
                      Ok(body) => {
                                 // Form parameters
                                 let param_enum_form_string =
-                                    None;
+                                    Some(models::TestEnumParametersRequestEnumFormString::Abc);
 
 
                                 let result = api_impl.test_enum_parameters(


### PR DESCRIPTION
Fixup minor bugs found in detailed testing of latest rust-server generator. 

1. Invalid variable names when using reserved terms. 
2. Invalid traits when field has no `type` specified.
3. Mishandling of data types for application/gzip endpoints. 
4. Empty default field when a default isn't specified for enum types.

Fixed 1 by not using the `r#` prefixing when an endpoint matches a reserved name, this broke compilation as the sanitized name was used in the middle of variable names which was invalid syntax.
Fixed 2 by not appending the `PartialOrd` trait when the type was unspecified. 
Fixed 3 by handling `isBinary` in various sections of the templates.
Fixed 4 by automatically generating default value from enum entry.

Tested on a variety of API documents for compilation, clippy and tests passing. 

_Fixed 4 for rust-server-deprecated so tests for that generator pass._

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
