### PR TITLE
feat: Add serde_validate support.

### DIFF
--- a/.github/workflows/samples-rust-server.yaml
+++ b/.github/workflows/samples-rust-server.yaml
@@ -60,6 +60,10 @@ jobs:
               cargo build --bin ${package##*/} --features cli
               target/debug/${package##*/} --help
             fi
+            # Test the validate feature if it exists
+            if cargo read-manifest | grep -q '"validate"'; then
+              cargo build --features validate --all-targets
+            fi
             cargo fmt
             cargo test
             cargo clippy

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustServerCodegen.java
@@ -86,6 +86,9 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
     private static final String problemJsonMimeType = "application/problem+json";
     private static final String problemXmlMimeType = "application/problem+xml";
 
+    // Track if we have models with conflicting names (Ok/Err) that conflict with serde_valid
+    private boolean hasConflictingModelNames = false;
+
     public RustServerCodegen() {
         super();
 
@@ -941,6 +944,11 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             if (param.contentType != null && isMimetypeJson(param.contentType)) {
                 param.vendorExtensions.put("x-consumes-json", true);
             }
+
+            // Add a vendor extension to flag if this can have validate() run on it.
+            if (!param.isUuid && !param.isPrimitiveType && !param.isEnum && (!param.isContainer || !languageSpecificPrimitives.contains(typeMapping.get(param.baseType)))) {
+                param.vendorExtensions.put("x-can-validate", true);
+            }
         }
 
         for (CodegenParameter param : op.formParams) {
@@ -1454,8 +1462,20 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);
 
+        // Check for reserved field names that conflict with serde_valid macro internals
+        if ("ok".equalsIgnoreCase(property.name) || "err".equalsIgnoreCase(property.name)) {
+            model.vendorExtensions.put("x-skip-serde-valid", true);
+        }
+
+        // Mark properties that reference complex types (models) for nested validation
+        // Only add nested validation for types that reference generated models (contain "models::")
+        if (property.dataType != null && property.dataType.contains("models::")) {
+            property.vendorExtensions.put("x-needs-nested-validation", true);
+        }
+
         // TODO: We should avoid reverse engineering primitive type status from the data type
-        if (!languageSpecificPrimitives.contains(stripNullable(property.dataType))) {
+        String strippedType = stripNullable(property.dataType);
+        if (!languageSpecificPrimitives.contains(strippedType)) {
             // If we use a more qualified model name, then only camelize the actual type, not the qualifier.
             if (property.dataType.contains(":")) {
                 int position = property.dataType.lastIndexOf(":");
@@ -1528,7 +1548,32 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
 
     @Override
     public ModelsMap postProcessModels(ModelsMap objs) {
-        return super.postProcessModelsEnum(objs);
+        ModelsMap result = super.postProcessModelsEnum(objs);
+
+        // Check for model names that conflict with serde_valid macro internals
+        // Once we find one, set a class-level flag that persists across all model batches
+        if (!hasConflictingModelNames) {
+            for (ModelMap modelMap : result.getModels()) {
+                CodegenModel model = modelMap.getModel();
+                if ("Ok".equalsIgnoreCase(model.classname) || "Err".equalsIgnoreCase(model.classname)) {
+                    hasConflictingModelNames = true;
+                    additionalProperties.put("hasConflictingModelNames", true);
+                    break;
+                }
+            }
+        }
+
+        // If there are conflicting names (detected in any batch), skip serde_valid for ALL models
+        if (hasConflictingModelNames) {
+            for (ModelMap modelMap : result.getModels()) {
+                CodegenModel model = modelMap.getModel();
+                model.vendorExtensions.put("x-skip-serde-valid", true);
+            }
+            // Set the flag for this batch's template context
+            result.put("hasConflictingModelNames", true);
+        }
+
+        return result;
     }
 
     private void processParam(CodegenParameter param, CodegenOperation op) {
@@ -1612,6 +1657,11 @@ public class RustServerCodegen extends AbstractRustCodegen implements CodegenCon
             param.vendorExtensions.put("x-format-string", "{:?}");
             String exampleString = (example != null) ? "Some(" + example + ")" : "None";
             param.vendorExtensions.put("x-example", exampleString);
+        }
+
+        // Add a vendor extension to flag if this can have validate() run on it.
+        if (!param.isUuid && !param.isPrimitiveType && !param.isEnum && (!param.isContainer || !languageSpecificPrimitives.contains(typeMapping.get(param.baseType)))) {
+           param.vendorExtensions.put("x-can-validate", true);
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -72,6 +72,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = [{{^apiUsesByteArray}}"regex",{{/apiUsesByteArray}} "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -100,6 +101,8 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/modules/openapi-generator/src/main/resources/rust-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/README.mustache
@@ -130,6 +130,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 

--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -1,10 +1,21 @@
 #![allow(unused_qualifications)]
-
+{{^hasConflictingModelNames}}
+#[cfg(not(feature = "validate"))]
 use validator::Validate;
 
 use crate::models;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::header;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
+{{/hasConflictingModelNames}}
+{{#hasConflictingModelNames}}
+use validator::Validate;
+
+use crate::models;
+#[cfg(any(feature = "client", feature = "server"))]
+use crate::header;
+{{/hasConflictingModelNames}}
 {{! Don't "use" structs here - they can conflict with the names of models, and mean that the code won't compile }}
 {{#models}}
 {{#model}}
@@ -19,6 +30,7 @@ use crate::header;
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+{{^hasConflictingModelNames}}{{^exts.x-skip-serde-valid}}#[cfg_attr(feature = "validate", derive(Validate))]{{/exts.x-skip-serde-valid}}{{/hasConflictingModelNames}}
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]{{#xmlName}}
 #[serde(rename = "{{{.}}}")]{{/xmlName}}
 pub enum {{{classname}}} {
@@ -60,11 +72,14 @@ impl std::str::FromStr for {{{classname}}} {
 {{^isEnum}}
 {{#dataType}}
 #[derive(Debug, Clone, PartialEq, {{#exts.x-partial-ord}}PartialOrd, {{/exts.x-partial-ord}}serde::Serialize, serde::Deserialize)]
+{{^hasConflictingModelNames}}{{^exts.x-skip-serde-valid}}#[cfg_attr(feature = "validate", derive(Validate))]{{/exts.x-skip-serde-valid}}{{/hasConflictingModelNames}}
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 {{#xmlName}}
 #[serde(rename = "{{{.}}}")]
 {{/xmlName}}
-pub struct {{{classname}}}({{{dataType}}});
+pub struct {{{classname}}}(
+{{>validate}}    {{{dataType}}}
+);
 
 impl std::convert::From<{{{dataType}}}> for {{{classname}}} {
     fn from(x: {{{dataType}}}) -> Self {
@@ -176,6 +191,7 @@ where
 {{/exts}}
 {{! vec}}
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+{{^hasConflictingModelNames}}{{^exts.x-skip-serde-valid}}#[cfg_attr(feature = "validate", derive(Validate))]{{/exts.x-skip-serde-valid}}{{/hasConflictingModelNames}}
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct {{{classname}}}(
 {{#exts}}
@@ -272,7 +288,7 @@ impl std::str::FromStr for {{{classname}}} {
 {{/arrayModelType}}
 {{^arrayModelType}}
 {{! general struct}}
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 {{#xmlName}}
 #[serde(rename = "{{{.}}}")]
@@ -288,7 +304,12 @@ pub struct {{{classname}}} {
 {{/x-item-xml-name}}
 {{/exts}}
 {{#hasValidation}}
+{{^hasConflictingModelNames}}
+    #[cfg_attr(not(feature = "validate"), validate(
+{{/hasConflictingModelNames}}
+{{#hasConflictingModelNames}}
     #[validate(
+{{/hasConflictingModelNames}}
         {{#maxLength}}
             {{#minLength}}
             length(min = {{minLength}}, max = {{maxLength}}),
@@ -336,8 +357,19 @@ pub struct {{{classname}}} {
             length(min = {{minItems}}),
             {{/minItems}}
         {{/maxItems}}
+{{^hasConflictingModelNames}}
+        ))]
+{{/hasConflictingModelNames}}
+{{#hasConflictingModelNames}}
         )]
+{{/hasConflictingModelNames}}
 {{/hasValidation}}
+{{^hasConflictingModelNames}}{{>validate}}{{/hasConflictingModelNames}}
+{{^hasConflictingModelNames}}
+{{#exts.x-needs-nested-validation}}
+    #[cfg_attr(feature = "validate", validate)]
+{{/exts.x-needs-nested-validation}}
+{{/hasConflictingModelNames}}
 {{#required}}
     pub {{{name}}}: {{{dataType}}},
 {{/required}}
@@ -346,6 +378,11 @@ pub struct {{{classname}}} {
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
 {{/isNullable}}
+{{^hasConflictingModelNames}}
+{{#exts.x-needs-nested-validation}}
+    #[cfg_attr(feature = "validate", validate)]
+{{/exts.x-needs-nested-validation}}
+{{/hasConflictingModelNames}}
     #[serde(skip_serializing_if="Option::is_none")]
     pub {{{name}}}: Option<{{{dataType}}}>,
 {{/required}}
@@ -365,6 +402,7 @@ lazy_static::lazy_static! {
 lazy_static::lazy_static! {
     static ref RE_{{#lambda.uppercase}}{{{classname}}}_{{{name}}}{{/lambda.uppercase}}: regex::bytes::Regex = regex::bytes::Regex::new(r"{{ pattern }}").unwrap();
 }
+#[cfg(not(feature = "validate"))]
 fn validate_byte_{{#lambda.lowercase}}{{{classname}}}_{{{name}}}{{/lambda.lowercase}}(
     b: &swagger::ByteArray
 ) -> Result<(), validator::ValidationError> {

--- a/modules/openapi-generator/src/main/resources/rust-server/server-imports.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-imports.mustache
@@ -4,6 +4,8 @@ use http_body_util::{combinators::BoxBody, Full};
 use hyper::{body::{Body, Incoming}, HeaderMap, Request, Response, StatusCode};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 #[allow(unused_imports)]
 use std::convert::{TryFrom, TryInto};
 use std::{convert::Infallible, error::Error};

--- a/modules/openapi-generator/src/main/resources/rust-server/server-make-service.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-make-service.mustache
@@ -9,6 +9,7 @@ where
     multipart_form_size_limit: Option<u64>,
 {{/apiUsesMultipartFormData}}
     marker: PhantomData<C>,
+    validation: bool
 }
 
 impl<T, C> MakeService<T, C>
@@ -22,7 +23,8 @@ where
 {{#apiUsesMultipartFormData}}
             multipart_form_size_limit: Some(8 * 1024 * 1024),
 {{/apiUsesMultipartFormData}}
-            marker: PhantomData
+            marker: PhantomData,
+            validation: false
         }
     }
 {{#apiUsesMultipartFormData}}
@@ -37,6 +39,12 @@ where
         self
     }
 {{/apiUsesMultipartFormData}}
+
+    // Turn on/off validation for the service being made.
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation;
+    }
 }
 
 impl<T, C> Clone for MakeService<T, C>
@@ -51,6 +59,7 @@ where
             multipart_form_size_limit: Some(8 * 1024 * 1024),
 {{/apiUsesMultipartFormData}}
             marker: PhantomData,
+            validation: self.validation
         }
     }
 }
@@ -65,10 +74,8 @@ where
     type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
     fn call(&self, target: Target) -> Self::Future {
-        let service = Service::new(self.api_impl.clone()){{^apiUsesMultipartFormData}};{{/apiUsesMultipartFormData}}
-{{#apiUsesMultipartFormData}}
-            .multipart_form_size_limit(self.multipart_form_size_limit);
-{{/apiUsesMultipartFormData}}
+        let service = Service::new(self.api_impl.clone(), self.validation){{^apiUsesMultipartFormData}};{{/apiUsesMultipartFormData}}{{#apiUsesMultipartFormData}}
+            .multipart_form_size_limit(self.multipart_form_size_limit);{{/apiUsesMultipartFormData}}
 
         future::ok(service)
     }

--- a/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
@@ -187,6 +187,10 @@
                         .expect("Unable to create Bad Request response for missing query parameter {{{baseName}}}")),
                 };
     {{/required}}
+    {{#exts.x-can-validate}}
+    #[cfg(not(feature = "validate"))]
+                run_validation!(param_{{{paramName}}}, "{{{baseName}}}", validation);
+    {{/exts.x-can-validate}}
   {{/isArray}}
   {{#-last}}
 

--- a/modules/openapi-generator/src/main/resources/rust-server/server-request-body-basic.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-request-body-basic.mustache
@@ -57,3 +57,7 @@
                                                         .expect("Unable to create Bad Request response for missing body parameter {{{baseName}}}")),
                                 };
         {{/required}}
+        {{#exts.x-can-validate}}
+        #[cfg(not(feature = "validate"))]
+                                run_validation!(param_{{{paramName}}}, "{{{baseName}}}", validation);
+        {{/exts.x-can-validate}}

--- a/modules/openapi-generator/src/main/resources/rust-server/server-service-footer.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-service-footer.mustache
@@ -6,9 +6,8 @@
         Box::pin(run(
             self.api_impl.clone(),
             req,
-{{#apiUsesMultipartFormData}}
-            self.multipart_form_size_limit,
-{{/apiUsesMultipartFormData}}
+            self.validation{{#apiUsesMultipartFormData}},
+            self.multipart_form_size_limit{{/apiUsesMultipartFormData}}
         ))
     }
 }

--- a/modules/openapi-generator/src/main/resources/rust-server/server-service-header.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-service-header.mustache
@@ -6,6 +6,31 @@ fn method_not_allowed() -> Result<Response<BoxBody<Bytes, Infallible>>, crate::S
     )
 }
 
+#[allow(unused_macros)]
+#[cfg(not(feature = "validate"))]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => ();
+}
+
+#[allow(unused_macros)]
+#[cfg(feature = "validate")]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => {
+        let $parameter = if $validation {
+            match $parameter.validate() {
+            Ok(()) => $parameter,
+            Err(e) => return Ok(Response::builder()
+                                    .status(StatusCode::BAD_REQUEST)
+                                    .header(CONTENT_TYPE, mime::TEXT_PLAIN.as_ref())
+                                    .body(BoxBody::new(format!("Invalid value in body parameter {}: {}", $base_name, e)))
+                                    .expect(&format!("Unable to create Bad Request response for invalid value in body parameter {}", $base_name))),
+            }
+        } else {
+            $parameter
+        };
+    }
+}
+
 pub struct Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString> {{#hasAuthMethods}}+ Has<Option<Authorization>>{{/hasAuthMethods}} + Send + Sync + 'static
@@ -15,21 +40,29 @@ pub struct Service<T, C> where
     multipart_form_size_limit: Option<u64>,
 {{/apiUsesMultipart}}
     marker: PhantomData<C>,
+    // Enable regex pattern validation of received JSON models
+    validation: bool,
 }
 
 impl<T, C> Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString> {{#hasAuthMethods}}+ Has<Option<Authorization>>{{/hasAuthMethods}} + Send + Sync + 'static
 {
-    pub fn new(api_impl: T) -> Self {
+    pub fn new(api_impl: T, validation: bool) -> Self {
         Service {
             api_impl,
 {{#apiUsesMultipart}}
             multipart_form_size_limit: Some(8 * 1024 * 1024),
 {{/apiUsesMultipart}}
-            marker: PhantomData
+            marker: PhantomData,
+            validation,
         }
     }
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation
+    }
+
 {{#apiUsesMultipart}}
 
     /// Configure size limit when extracting a multipart/form body.
@@ -55,6 +88,7 @@ impl<T, C> Clone for Service<T, C> where
             multipart_form_size_limit: Some(8 * 1024 * 1024),
 {{/apiUsesMultipart}}
             marker: self.marker,
+            validation: self.validation,
         }
     }
 }
@@ -83,6 +117,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         async fn run<T, C, ReqBody>(
             mut api_impl: T,
             req: (Request<ReqBody>, C),
+            validation: bool,
 {{#apiUsesMultipartFormData}}
             multipart_form_size_limit: Option<u64>,
 {{/apiUsesMultipartFormData}}

--- a/modules/openapi-generator/src/main/resources/rust-server/validate.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/validate.mustache
@@ -1,0 +1,60 @@
+{{#exts.x-true-type}}
+{{#minimum}}
+  {{#exclusiveMinimum}}
+    #[cfg_attr(feature = "validate", validate(exclusive_minimum = {{{minimum}}}{{{exts.x-true-type}}}))]
+  {{/exclusiveMinimum}}
+  {{^exclusiveMinimum}}
+    #[cfg_attr(feature = "validate", validate(minimum = {{{minimum}}}{{{exts.x-true-type}}}))]
+  {{/exclusiveMinimum}}
+{{/minimum}}
+{{#maximum}}
+  {{#exclusiveMaximum}}
+    #[cfg_attr(feature = "validate", validate(exclusive_maximum = {{{maximum}}}{{{exts.x-true-type}}}))]
+  {{/exclusiveMaximum}}
+  {{^exclusiveMaximum}}
+    #[cfg_attr(feature = "validate", validate(maximum = {{{maximum}}}{{{exts.x-true-type}}}))]
+  {{/exclusiveMaximum}}
+{{/maximum}}
+{{/exts.x-true-type}}
+{{^exts.x-true-type}}
+{{#minimum}}
+  {{#exclusiveMinimum}}
+    #[cfg_attr(feature = "validate", validate(exclusive_minimum = {{{minimum}}}{{{dataType}}}))]
+  {{/exclusiveMinimum}}
+  {{^exclusiveMinimum}}
+    #[cfg_attr(feature = "validate", validate(minimum = {{{minimum}}}{{{dataType}}}))]
+  {{/exclusiveMinimum}}
+{{/minimum}}
+{{#maximum}}
+  {{#exclusiveMaximum}}
+    #[cfg_attr(feature = "validate", validate(exclusive_maximum = {{{maximum}}}{{{dataType}}}))]
+  {{/exclusiveMaximum}}
+  {{^exclusiveMaximum}}
+    #[cfg_attr(feature = "validate", validate(maximum = {{{maximum}}}{{{dataType}}}))]
+  {{/exclusiveMaximum}}
+{{/maximum}}
+{{/exts.x-true-type}}
+{{#minLength}}
+    #[cfg_attr(feature = "validate", validate(min_length = {{{minLength}}}))]
+{{/minLength}}
+{{#maxLength}}
+    #[cfg_attr(feature = "validate", validate(max_length = {{{maxLength}}}))]
+{{/maxLength}}
+{{#pattern}}
+{{^isByteArray}}
+    #[cfg_attr(feature = "validate", validate(pattern = r"{{{pattern}}}"))]
+{{/isByteArray}}
+{{/pattern}}
+{{#minItems}}
+    #[cfg_attr(feature = "validate", validate(min_length = {{{minItems}}}))]
+{{/minItems}}
+{{#maxItems}}
+    #[cfg_attr(feature = "validate", validate(max_length = {{{maxItems}}}))]
+{{/maxItems}}
+{{#isEnum}}
+  {{#allowableValues}}
+    {{#isString}}
+    #[cfg_attr(feature = "validate", validate(enumerate({{#enumVars}}{{{value}}}, {{/enumVars}})))]
+    {{/isString}}
+  {{/allowableValues}}
+{{/isEnum}}

--- a/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/rust-server/rust-server-test.yaml
@@ -172,6 +172,19 @@ definitions:
       value:
         description: Inner string
         type: string
+  unnamed_allof_under_properties:
+    description: Model for testing allOf references inside properties
+    properties:
+      name:
+        allOf:
+          - $ref: '#/definitions/unnamed_reference'
+  unnamed_reference:
+    type: integer
+    maximum: 30
+    exclusiveMaximum: true
+    minimum: 5
+    exclusiveMinimum: true
+    format: int32
   # Currently broken - see https://github.com/OpenAPITools/openapi-generator/issues/8
   # ArrayOfObjects:
   #   description: An array of objects

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/.openapi-generator/FILES
@@ -12,6 +12,8 @@ docs/DummyPutRequest.md
 docs/GetYamlResponse.md
 docs/ObjectOfObjects.md
 docs/ObjectOfObjectsInner.md
+docs/UnnamedAllofUnderProperties.md
+docs/UnnamedReference.md
 docs/default_api.md
 examples/ca.pem
 examples/client/client_auth.rs

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/README.md
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/README.md
@@ -149,6 +149,8 @@ Method | HTTP request | Description
  - [GetYamlResponse](docs/GetYamlResponse.md)
  - [ObjectOfObjects](docs/ObjectOfObjects.md)
  - [ObjectOfObjectsInner](docs/ObjectOfObjectsInner.md)
+ - [UnnamedAllofUnderProperties](docs/UnnamedAllofUnderProperties.md)
+ - [UnnamedReference](docs/UnnamedReference.md)
 
 
 ## Documentation For Authorization

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/api/openapi.yaml
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/api/openapi.yaml
@@ -183,6 +183,21 @@ components:
           description: Inner string
           type: string
       type: object
+    unnamed_allof_under_properties:
+      description: Model for testing allOf references inside properties
+      properties:
+        name:
+          allOf:
+          - $ref: "#/components/schemas/unnamed_reference"
+          type: object
+      type: object
+    unnamed_reference:
+      exclusiveMaximum: true
+      exclusiveMinimum: true
+      format: int32
+      maximum: 30
+      minimum: 5
+      type: integer
     dummyPut_request:
       properties:
         id:

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/docs/UnnamedAllofUnderProperties.md
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/docs/UnnamedAllofUnderProperties.md
@@ -1,0 +1,10 @@
+# UnnamedAllofUnderProperties
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | **u32** |  | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/docs/UnnamedReference.md
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/docs/UnnamedReference.md
@@ -1,0 +1,9 @@
+# UnnamedReference
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server-deprecated/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server-deprecated/output/rust-server-test/src/models.rs
@@ -1305,3 +1305,298 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
         }
     }
 }
+
+/// Model for testing allOf references inside properties
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct UnnamedAllofUnderProperties {
+    #[serde(rename = "name")]
+    #[validate(
+            range(min = 5, max = 30),
+        )]
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub name: Option<u32>,
+
+}
+
+
+impl UnnamedAllofUnderProperties {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> UnnamedAllofUnderProperties {
+        UnnamedAllofUnderProperties {
+            name: None,
+        }
+    }
+}
+
+/// Converts the UnnamedAllofUnderProperties value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for UnnamedAllofUnderProperties {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> = vec![
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+        ];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a UnnamedAllofUnderProperties value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for UnnamedAllofUnderProperties {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub name: Vec<u32>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => return std::result::Result::Err("Missing value while parsing UnnamedAllofUnderProperties".to_string())
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "name" => intermediate_rep.name.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing UnnamedAllofUnderProperties".to_string())
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(UnnamedAllofUnderProperties {
+            name: intermediate_rep.name.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<UnnamedAllofUnderProperties> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<UnnamedAllofUnderProperties>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<UnnamedAllofUnderProperties>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UnnamedAllofUnderProperties - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<UnnamedAllofUnderProperties> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <UnnamedAllofUnderProperties as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into UnnamedAllofUnderProperties - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<UnnamedAllofUnderProperties>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<UnnamedAllofUnderProperties>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<UnnamedAllofUnderProperties>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<UnnamedAllofUnderProperties> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <UnnamedAllofUnderProperties as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into UnnamedAllofUnderProperties - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct UnnamedReference(i32);
+
+impl std::convert::From<i32> for UnnamedReference {
+    fn from(x: i32) -> Self {
+        UnnamedReference(x)
+    }
+}
+
+impl std::convert::From<UnnamedReference> for i32 {
+    fn from(x: UnnamedReference) -> Self {
+        x.0
+    }
+}
+
+impl std::ops::Deref for UnnamedReference {
+    type Target = i32;
+    fn deref(&self) -> &i32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for UnnamedReference {
+    fn deref_mut(&mut self) -> &mut i32 {
+        &mut self.0
+    }
+}
+
+/// Converts the UnnamedReference value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl ::std::string::ToString for UnnamedReference {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a UnnamedReference value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl ::std::str::FromStr for UnnamedReference {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match std::str::FromStr::from_str(s) {
+             std::result::Result::Ok(r) => std::result::Result::Ok(UnnamedReference(r)),
+             std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {s} to UnnamedReference: {e:?}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<UnnamedReference> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<UnnamedReference>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<UnnamedReference>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UnnamedReference - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<UnnamedReference> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <UnnamedReference as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into UnnamedReference - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<UnnamedReference>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<UnnamedReference>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<UnnamedReference>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<UnnamedReference> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <UnnamedReference as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into UnnamedReference - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -26,6 +26,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = [ "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -52,6 +53,8 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/samples/server/petstore/rust-server/output/multipart-v3/README.md
+++ b/samples/server/petstore/rust-server/output/multipart-v3/README.md
@@ -115,6 +115,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/models.rs
@@ -1,23 +1,30 @@
 #![allow(unused_qualifications)]
-
+#[cfg(not(feature = "validate"))]
 use validator::Validate;
 
 use crate::models;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::header;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MultipartRelatedRequest {
     #[serde(rename = "object_field")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub object_field: Option<models::MultipartRequestObjectField>,
 
     #[serde(rename = "optional_binary_field")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub optional_binary_field: Option<swagger::ByteArray>,
 
     #[serde(rename = "required_binary_field")]
+
     pub required_binary_field: swagger::ByteArray,
 
 }
@@ -179,13 +186,15 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MultipartRequestObjectField {
     #[serde(rename = "field_a")]
+
     pub field_a: String,
 
     #[serde(rename = "field_b")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub field_b: Option<Vec<String>>,
 
@@ -349,14 +358,16 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MultipleIdenticalMimeTypesPostRequest {
     #[serde(rename = "binary1")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub binary1: Option<swagger::ByteArray>,
 
     #[serde(rename = "binary2")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub binary2: Option<swagger::ByteArray>,
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/no-example-v3/Cargo.toml
@@ -22,6 +22,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -46,6 +47,8 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/samples/server/petstore/rust-server/output/no-example-v3/README.md
+++ b/samples/server/petstore/rust-server/output/no-example-v3/README.md
@@ -112,6 +112,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/models.rs
@@ -1,15 +1,18 @@
 #![allow(unused_qualifications)]
-
+#[cfg(not(feature = "validate"))]
 use validator::Validate;
 
 use crate::models;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::header;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct OpGetRequest {
     #[serde(rename = "property")]
+
     pub property: String,
 
 }

--- a/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/openapi-v3/Cargo.toml
@@ -25,6 +25,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = [ "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -51,6 +52,8 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/samples/server/petstore/rust-server/output/openapi-v3/README.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/README.md
@@ -143,6 +143,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/ModelErr.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/ModelErr.md
@@ -1,0 +1,9 @@
+# ModelErr
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/ModelOk.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/ModelOk.md
@@ -1,0 +1,9 @@
+# ModelOk
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/NamedAllofUnderProperties.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/NamedAllofUnderProperties.md
@@ -1,0 +1,10 @@
+# NamedAllofUnderProperties
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | [***models::NamedReference**](named_reference.md) |  | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/NamedReference.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/NamedReference.md
@@ -1,0 +1,10 @@
+# NamedReference
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name2** | **i32** |  | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/NullableFloat.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/NullableFloat.md
@@ -1,0 +1,9 @@
+# NullableFloat
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/UnnamedAllofUnderProperties.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/UnnamedAllofUnderProperties.md
@@ -1,0 +1,10 @@
+# UnnamedAllofUnderProperties
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | **i32** |  | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/docs/UnnamedReference.md
+++ b/samples/server/petstore/rust-server/output/openapi-v3/docs/UnnamedReference.md
@@ -1,0 +1,9 @@
+# UnnamedReference
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/callbacks.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/callbacks.rs
@@ -4,6 +4,8 @@ use http_body_util::{combinators::BoxBody, Full};
 use hyper::{body::{Body, Incoming}, HeaderMap, Request, Response, StatusCode};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 #[allow(unused_imports)]
 use std::convert::{TryFrom, TryInto};
 use std::{convert::Infallible, error::Error};
@@ -61,6 +63,7 @@ where
 {
     api_impl: T,
     marker: PhantomData<C>,
+    validation: bool
 }
 
 impl<T, C> MakeService<T, C>
@@ -71,8 +74,15 @@ where
     pub fn new(api_impl: T) -> Self {
         MakeService {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation: false
         }
+    }
+
+    // Turn on/off validation for the service being made.
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation;
     }
 }
 
@@ -85,6 +95,7 @@ where
         Self {
             api_impl: self.api_impl.clone(),
             marker: PhantomData,
+            validation: self.validation
         }
     }
 }
@@ -99,7 +110,7 @@ where
     type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
     fn call(&self, target: Target) -> Self::Future {
-        let service = Service::new(self.api_impl.clone());
+        let service = Service::new(self.api_impl.clone(), self.validation);
 
         future::ok(service)
     }
@@ -114,24 +125,57 @@ fn method_not_allowed() -> Result<Response<BoxBody<Bytes, Infallible>>, crate::S
     )
 }
 
+#[allow(unused_macros)]
+#[cfg(not(feature = "validate"))]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => ();
+}
+
+#[allow(unused_macros)]
+#[cfg(feature = "validate")]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => {
+        let $parameter = if $validation {
+            match $parameter.validate() {
+            Ok(()) => $parameter,
+            Err(e) => return Ok(Response::builder()
+                                    .status(StatusCode::BAD_REQUEST)
+                                    .header(CONTENT_TYPE, mime::TEXT_PLAIN.as_ref())
+                                    .body(BoxBody::new(format!("Invalid value in body parameter {}: {}", $base_name, e)))
+                                    .expect(&format!("Unable to create Bad Request response for invalid value in body parameter {}", $base_name))),
+            }
+        } else {
+            $parameter
+        };
+    }
+}
+
 pub struct Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString> + Has<Option<Authorization>> + Send + Sync + 'static
 {
     api_impl: T,
     marker: PhantomData<C>,
+    // Enable regex pattern validation of received JSON models
+    validation: bool,
 }
 
 impl<T, C> Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString> + Has<Option<Authorization>> + Send + Sync + 'static
 {
-    pub fn new(api_impl: T) -> Self {
+    pub fn new(api_impl: T, validation: bool) -> Self {
         Service {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation,
         }
     }
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation
+    }
+
 }
 
 impl<T, C> Clone for Service<T, C> where
@@ -142,6 +186,7 @@ impl<T, C> Clone for Service<T, C> where
         Service {
             api_impl: self.api_impl.clone(),
             marker: self.marker,
+            validation: self.validation,
         }
     }
 }
@@ -170,6 +215,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         async fn run<T, C, ReqBody>(
             mut api_impl: T,
             req: (Request<ReqBody>, C),
+            validation: bool,
         ) -> Result<Response<BoxBody<Bytes, Infallible>>, crate::ServiceError>
         where
             T: Api<C> + Clone + Send + 'static,
@@ -298,6 +344,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         Box::pin(run(
             self.api_impl.clone(),
             req,
+            self.validation
         ))
     }
 }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/models.rs
@@ -1,5 +1,4 @@
 #![allow(unused_qualifications)]
-
 use validator::Validate;
 
 use crate::models;
@@ -8,8 +7,11 @@ use crate::header;
 
 /// Check that an object with only additional properties that references another object (e.g. an anyOf object) isn't treated as freeForm
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AdditionalPropertiesReferencedAnyOfObject(std::collections::HashMap<String, models::AnyOfProperty>);
+pub struct AdditionalPropertiesReferencedAnyOfObject(
+    std::collections::HashMap<String, models::AnyOfProperty>
+);
 
 impl std::convert::From<std::collections::HashMap<String, models::AnyOfProperty>> for AdditionalPropertiesReferencedAnyOfObject {
     fn from(x: std::collections::HashMap<String, models::AnyOfProperty>) -> Self {
@@ -145,8 +147,11 @@ impl AdditionalPropertiesReferencedAnyOfObject {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AdditionalPropertiesWithList(std::collections::HashMap<String, Vec<String>>);
+pub struct AdditionalPropertiesWithList(
+    std::collections::HashMap<String, Vec<String>>
+);
 
 impl std::convert::From<std::collections::HashMap<String, Vec<String>>> for AdditionalPropertiesWithList {
     fn from(x: std::collections::HashMap<String, Vec<String>>) -> Self {
@@ -281,16 +286,18 @@ impl AdditionalPropertiesWithList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AdditionalPropertiesWithNullable {
     #[serde(rename = "nullableString")]
+
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_string: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "nullableMap")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_map: Option<std::collections::HashMap<String, swagger::Nullable<models::NullableObject>>>,
 
@@ -478,6 +485,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AnotherXmlArray(
     #[serde(serialize_with = "wrap_in_snake_another_xml_inner")]
@@ -656,9 +664,12 @@ impl AnotherXmlArray {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "snake_another_xml_inner")]
-pub struct AnotherXmlInner(String);
+pub struct AnotherXmlInner(
+    String
+);
 
 impl std::convert::From<String> for AnotherXmlInner {
     fn from(x: String) -> Self {
@@ -786,11 +797,12 @@ impl AnotherXmlInner {
 }
 
 /// An XML object
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "snake_another_xml_object")]
 pub struct AnotherXmlObject {
     #[serde(rename = "inner_string")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner_string: Option<String>,
 
@@ -967,8 +979,11 @@ impl AnotherXmlObject {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AnyOfGet202Response(swagger::AnyOf2<models::StringObject,models::UuidObject>);
+pub struct AnyOfGet202Response(
+    swagger::AnyOf2<models::StringObject,models::UuidObject>
+);
 
 impl std::convert::From<swagger::AnyOf2<models::StringObject,models::UuidObject>> for AnyOfGet202Response {
     fn from(x: swagger::AnyOf2<models::StringObject,models::UuidObject>) -> Self {
@@ -1105,8 +1120,11 @@ impl AnyOfGet202Response {
 
 /// Test a model containing an anyOf of a hash map
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AnyOfHashMapObject(swagger::AnyOf2<String,std::collections::HashMap<String, String>>);
+pub struct AnyOfHashMapObject(
+    swagger::AnyOf2<String,std::collections::HashMap<String, String>>
+);
 
 impl std::convert::From<swagger::AnyOf2<String,std::collections::HashMap<String, String>>> for AnyOfHashMapObject {
     fn from(x: swagger::AnyOf2<String,std::collections::HashMap<String, String>>) -> Self {
@@ -1243,8 +1261,11 @@ impl AnyOfHashMapObject {
 
 /// Test a model containing an anyOf
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AnyOfObject(swagger::AnyOf2<models::AnyOfObjectAnyOf,String>);
+pub struct AnyOfObject(
+    swagger::AnyOf2<models::AnyOfObjectAnyOf,String>
+);
 
 impl std::convert::From<swagger::AnyOf2<models::AnyOfObjectAnyOf,String>> for AnyOfObject {
     fn from(x: swagger::AnyOf2<models::AnyOfObjectAnyOf,String>) -> Self {
@@ -1385,6 +1406,7 @@ impl AnyOfObject {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum AnyOfObjectAnyOf {
     #[serde(rename = "FOO")]
@@ -1502,13 +1524,15 @@ impl AnyOfObjectAnyOf {
 }
 
 /// Test containing an anyOf object
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AnyOfProperty {
     #[serde(rename = "requiredAnyOf")]
+
     pub required_any_of: models::AnyOfObject,
 
     #[serde(rename = "optionalAnyOf")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub optional_any_of: Option<models::Model12345AnyOfObject>,
 
@@ -1677,16 +1701,18 @@ impl AnyOfProperty {
 }
 
 /// An XML object
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "camelDuplicateXmlObject")]
 pub struct DuplicateXmlObject {
     #[serde(rename = "inner_string")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner_string: Option<String>,
 
     #[serde(rename = "inner_array")]
     #[serde(serialize_with = "wrap_in_camelXmlInner")]
+
     pub inner_array: models::XmlArray,
 
 }
@@ -1874,6 +1900,7 @@ impl DuplicateXmlObject {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumWithStarObject {
     #[serde(rename = "FOO")]
@@ -1995,8 +2022,11 @@ impl EnumWithStarObject {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct Err(String);
+pub struct Err(
+    String
+);
 
 impl std::convert::From<String> for Err {
     fn from(x: String) -> Self {
@@ -2124,8 +2154,11 @@ impl Err {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct Error(String);
+pub struct Error(
+    String
+);
 
 impl std::convert::From<String> for Error {
     fn from(x: String) -> Self {
@@ -2258,6 +2291,7 @@ impl Error {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum FormTestRequestEnumField {
     #[serde(rename = "one_enum")]
@@ -2372,8 +2406,11 @@ impl FormTestRequestEnumField {
 
 /// Test a model containing an anyOf that starts with a number
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct Model12345AnyOfObject(swagger::AnyOf2<models::Model12345AnyOfObjectAnyOf,String>);
+pub struct Model12345AnyOfObject(
+    swagger::AnyOf2<models::Model12345AnyOfObjectAnyOf,String>
+);
 
 impl std::convert::From<swagger::AnyOf2<models::Model12345AnyOfObjectAnyOf,String>> for Model12345AnyOfObject {
     fn from(x: swagger::AnyOf2<models::Model12345AnyOfObjectAnyOf,String>) -> Self {
@@ -2514,6 +2551,7 @@ impl Model12345AnyOfObject {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum Model12345AnyOfObjectAnyOf {
     #[serde(rename = "FOO")]
@@ -2634,10 +2672,11 @@ impl Model12345AnyOfObjectAnyOf {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MultigetGet201Response {
     #[serde(rename = "foo")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub foo: Option<String>,
 
@@ -2805,8 +2844,11 @@ impl MultigetGet201Response {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct MyId(i32);
+pub struct MyId(
+    i32
+);
 
 impl std::convert::From<i32> for MyId {
     fn from(x: i32) -> Self {
@@ -2944,6 +2986,7 @@ impl MyId {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MyIdList(
     Vec<i32>
@@ -3122,8 +3165,11 @@ impl MyIdList {
 
 /// An object with no type
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct NoTypeObject(serde_json::Value);
+pub struct NoTypeObject(
+    serde_json::Value
+);
 
 impl std::convert::From<serde_json::Value> for NoTypeObject {
     fn from(x: serde_json::Value) -> Self {
@@ -3261,8 +3307,11 @@ impl NoTypeObject {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct NullableObject(String);
+pub struct NullableObject(
+    String
+);
 
 impl std::convert::From<String> for NullableObject {
     fn from(x: String) -> Self {
@@ -3389,31 +3438,36 @@ impl NullableObject {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct NullableTest {
     #[serde(rename = "nullable")]
+
     pub nullable: swagger::Nullable<String>,
 
     #[serde(rename = "nullableWithNullDefault")]
+
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_null_default: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "nullableWithPresentDefault")]
+
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_present_default: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "nullableWithNoDefault")]
+
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_with_no_default: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "nullableArray")]
+
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
     #[serde(skip_serializing_if="Option::is_none")]
@@ -3423,6 +3477,7 @@ pub struct NullableTest {
     #[validate(
             length(min = 1),
         )]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub min_item_test: Option<Vec<i32>>,
 
@@ -3430,6 +3485,7 @@ pub struct NullableTest {
     #[validate(
             length(max = 2),
         )]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub max_item_test: Option<Vec<i32>>,
 
@@ -3437,6 +3493,7 @@ pub struct NullableTest {
     #[validate(
             length(min = 1, max = 3),
         )]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub min_max_item_test: Option<Vec<i32>>,
 
@@ -3668,13 +3725,15 @@ impl NullableTest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectHeader {
     #[serde(rename = "requiredObjectHeader")]
+
     pub required_object_header: bool,
 
     #[serde(rename = "optionalObjectHeader")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub optional_object_header: Option<i32>,
 
@@ -3848,16 +3907,18 @@ impl ObjectHeader {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectParam {
     #[serde(rename = "requiredParam")]
+
     pub required_param: bool,
 
     #[serde(rename = "optionalParam")]
     #[validate(
             range(min = 1u64, max = 10000000000000000000u64),
         )]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub optional_param: Option<u64>,
 
@@ -4031,20 +4092,24 @@ impl ObjectParam {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectUntypedProps {
     #[serde(rename = "required_untyped")]
+
     pub required_untyped: serde_json::Value,
 
     #[serde(rename = "required_untyped_nullable")]
+
     pub required_untyped_nullable: swagger::Nullable<serde_json::Value>,
 
     #[serde(rename = "not_required_untyped")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub not_required_untyped: Option<serde_json::Value>,
 
     #[serde(rename = "not_required_untyped_nullable")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub not_required_untyped_nullable: Option<serde_json::Value>,
 
@@ -4223,10 +4288,11 @@ impl ObjectUntypedProps {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectWithArrayOfObjects {
     #[serde(rename = "objectArray")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub object_array: Option<Vec<models::StringObject>>,
 
@@ -4393,8 +4459,11 @@ impl ObjectWithArrayOfObjects {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct Ok(String);
+pub struct Ok(
+    String
+);
 
 impl std::convert::From<String> for Ok {
     fn from(x: String) -> Self {
@@ -4522,8 +4591,11 @@ impl Ok {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct OneOfGet200Response(swagger::OneOf2<i32,Vec<String>>);
+pub struct OneOfGet200Response(
+    swagger::OneOf2<i32,Vec<String>>
+);
 
 impl std::convert::From<swagger::OneOf2<i32,Vec<String>>> for OneOfGet200Response {
     fn from(x: swagger::OneOf2<i32,Vec<String>>) -> Self {
@@ -4659,8 +4731,11 @@ impl OneOfGet200Response {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct OptionalObjectHeader(i32);
+pub struct OptionalObjectHeader(
+    i32
+);
 
 impl std::convert::From<i32> for OptionalObjectHeader {
     fn from(x: i32) -> Self {
@@ -4798,8 +4873,11 @@ impl OptionalObjectHeader {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct RequiredObjectHeader(bool);
+pub struct RequiredObjectHeader(
+    bool
+);
 
 impl std::convert::From<bool> for RequiredObjectHeader {
     fn from(x: bool) -> Self {
@@ -4937,8 +5015,11 @@ impl RequiredObjectHeader {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct Result(String);
+pub struct Result(
+    String
+);
 
 impl std::convert::From<String> for Result {
     fn from(x: String) -> Self {
@@ -5071,6 +5152,7 @@ impl Result {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum StringEnum {
     #[serde(rename = "FOO")]
@@ -5188,8 +5270,11 @@ impl StringEnum {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct StringObject(String);
+pub struct StringObject(
+    String
+);
 
 impl std::convert::From<String> for StringObject {
     fn from(x: String) -> Self {
@@ -5318,8 +5403,11 @@ impl StringObject {
 
 /// Test a model containing a UUID
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct UuidObject(uuid::Uuid);
+pub struct UuidObject(
+    uuid::Uuid
+);
 
 impl std::convert::From<uuid::Uuid> for UuidObject {
     fn from(x: uuid::Uuid) -> Self {
@@ -5473,6 +5561,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct XmlArray(
     #[serde(serialize_with = "wrap_in_camelXmlInner")]
@@ -5651,9 +5740,12 @@ impl XmlArray {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "camelXmlInner")]
-pub struct XmlInner(String);
+pub struct XmlInner(
+    String
+);
 
 impl std::convert::From<String> for XmlInner {
     fn from(x: String) -> Self {
@@ -5781,15 +5873,17 @@ impl XmlInner {
 }
 
 /// An XML object
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "camelXmlObject")]
 pub struct XmlObject {
     #[serde(rename = "innerString")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner_string: Option<String>,
 
     #[serde(rename = "other_inner_rename")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub other_inner_rename: Option<i32>,
 

--- a/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ops-v3/Cargo.toml
@@ -22,6 +22,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -46,6 +47,8 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/samples/server/petstore/rust-server/output/ops-v3/README.md
+++ b/samples/server/petstore/rust-server/output/ops-v3/README.md
@@ -149,6 +149,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 

--- a/samples/server/petstore/rust-server/output/ops-v3/src/models.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/models.rs
@@ -1,7 +1,9 @@
 #![allow(unused_qualifications)]
-
+#[cfg(not(feature = "validate"))]
 use validator::Validate;
 
 use crate::models;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::header;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;

--- a/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
@@ -4,6 +4,8 @@ use http_body_util::{combinators::BoxBody, Full};
 use hyper::{body::{Body, Incoming}, HeaderMap, Request, Response, StatusCode};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 #[allow(unused_imports)]
 use std::convert::{TryFrom, TryInto};
 use std::{convert::Infallible, error::Error};
@@ -156,6 +158,7 @@ where
 {
     api_impl: T,
     marker: PhantomData<C>,
+    validation: bool
 }
 
 impl<T, C> MakeService<T, C>
@@ -166,8 +169,15 @@ where
     pub fn new(api_impl: T) -> Self {
         MakeService {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation: false
         }
+    }
+
+    // Turn on/off validation for the service being made.
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation;
     }
 }
 
@@ -180,6 +190,7 @@ where
         Self {
             api_impl: self.api_impl.clone(),
             marker: PhantomData,
+            validation: self.validation
         }
     }
 }
@@ -194,7 +205,7 @@ where
     type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
     fn call(&self, target: Target) -> Self::Future {
-        let service = Service::new(self.api_impl.clone());
+        let service = Service::new(self.api_impl.clone(), self.validation);
 
         future::ok(service)
     }
@@ -208,24 +219,57 @@ fn method_not_allowed() -> Result<Response<BoxBody<Bytes, Infallible>>, crate::S
     )
 }
 
+#[allow(unused_macros)]
+#[cfg(not(feature = "validate"))]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => ();
+}
+
+#[allow(unused_macros)]
+#[cfg(feature = "validate")]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => {
+        let $parameter = if $validation {
+            match $parameter.validate() {
+            Ok(()) => $parameter,
+            Err(e) => return Ok(Response::builder()
+                                    .status(StatusCode::BAD_REQUEST)
+                                    .header(CONTENT_TYPE, mime::TEXT_PLAIN.as_ref())
+                                    .body(BoxBody::new(format!("Invalid value in body parameter {}: {}", $base_name, e)))
+                                    .expect(&format!("Unable to create Bad Request response for invalid value in body parameter {}", $base_name))),
+            }
+        } else {
+            $parameter
+        };
+    }
+}
+
 pub struct Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString>  + Send + Sync + 'static
 {
     api_impl: T,
     marker: PhantomData<C>,
+    // Enable regex pattern validation of received JSON models
+    validation: bool,
 }
 
 impl<T, C> Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString>  + Send + Sync + 'static
 {
-    pub fn new(api_impl: T) -> Self {
+    pub fn new(api_impl: T, validation: bool) -> Self {
         Service {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation,
         }
     }
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation
+    }
+
 }
 
 impl<T, C> Clone for Service<T, C> where
@@ -236,6 +280,7 @@ impl<T, C> Clone for Service<T, C> where
         Service {
             api_impl: self.api_impl.clone(),
             marker: self.marker,
+            validation: self.validation,
         }
     }
 }
@@ -264,6 +309,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         async fn run<T, C, ReqBody>(
             mut api_impl: T,
             req: (Request<ReqBody>, C),
+            validation: bool,
         ) -> Result<Response<BoxBody<Bytes, Infallible>>, crate::ServiceError>
         where
             T: Api<C> + Clone + Send + 'static,
@@ -1434,6 +1480,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         Box::pin(run(
             self.api_impl.clone(),
             req,
+            self.validation
         ))
     }
 }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -26,6 +26,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = [ "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -52,6 +53,8 @@ regex = "1.12"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/README.md
@@ -137,6 +137,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/models.rs
@@ -1,19 +1,23 @@
 #![allow(unused_qualifications)]
-
+#[cfg(not(feature = "validate"))]
 use validator::Validate;
 
 use crate::models;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::header;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AdditionalPropertiesClass {
     #[serde(rename = "map_property")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_property: Option<std::collections::HashMap<String, String>>,
 
     #[serde(rename = "map_of_map_property")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_of_map_property: Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
 
@@ -179,13 +183,15 @@ impl AdditionalPropertiesClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Animal {
     #[serde(rename = "className")]
+
     pub class_name: String,
 
     #[serde(rename = "color")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
 
@@ -360,6 +366,7 @@ impl Animal {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AnimalFarm(
     Vec<Animal>
@@ -536,18 +543,21 @@ impl AnimalFarm {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ApiResponse {
     #[serde(rename = "code")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub code: Option<i32>,
 
     #[serde(rename = "type")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub r#type: Option<String>,
 
     #[serde(rename = "message")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub message: Option<String>,
 
@@ -736,10 +746,11 @@ impl ApiResponse {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ArrayOfArrayOfNumberOnly {
     #[serde(rename = "ArrayArrayNumber")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_number: Option<Vec<Vec<f64>>>,
 
@@ -900,10 +911,11 @@ impl ArrayOfArrayOfNumberOnly {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ArrayOfNumberOnly {
     #[serde(rename = "ArrayNumber")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_number: Option<Vec<f64>>,
 
@@ -1069,22 +1081,30 @@ impl ArrayOfNumberOnly {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ArrayTest {
     #[serde(rename = "array_of_string")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_of_string: Option<Vec<String>>,
 
     #[serde(rename = "array_array_of_integer")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_of_integer: Option<Vec<Vec<i64>>>,
 
     #[serde(rename = "array_array_of_model")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_of_model: Option<Vec<Vec<models::ReadOnlyFirst>>>,
 
     #[serde(rename = "array_of_enum")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_of_enum: Option<Vec<models::MapTestMapMapOfEnumValueValue>>,
 
@@ -1265,31 +1285,37 @@ impl ArrayTest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Capitalization {
     #[serde(rename = "smallCamel")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub small_camel: Option<String>,
 
     #[serde(rename = "CapitalCamel")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub capital_camel: Option<String>,
 
     #[serde(rename = "small_Snake")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub small_snake: Option<String>,
 
     #[serde(rename = "Capital_Snake")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub capital_snake: Option<String>,
 
     #[serde(rename = "SCA_ETH_Flow_Points")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub sca_eth_flow_points: Option<String>,
 
     /// Name of the pet 
     #[serde(rename = "ATT_NAME")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub att_name: Option<String>,
 
@@ -1511,17 +1537,20 @@ impl Capitalization {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Cat {
     #[serde(rename = "className")]
+
     pub class_name: String,
 
     #[serde(rename = "color")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
 
     #[serde(rename = "declawed")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub declawed: Option<bool>,
 
@@ -1706,15 +1735,17 @@ impl Cat {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "Category")]
 pub struct Category {
     #[serde(rename = "id")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "name")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 
@@ -1893,10 +1924,11 @@ impl Category {
 }
 
 /// Model for testing model with \"_class\" property
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ClassModel {
     #[serde(rename = "_class")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub _class: Option<String>,
 
@@ -2063,10 +2095,11 @@ impl ClassModel {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Client {
     #[serde(rename = "client")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub client: Option<String>,
 
@@ -2233,17 +2266,20 @@ impl Client {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Dog {
     #[serde(rename = "className")]
+
     pub class_name: String,
 
     #[serde(rename = "color")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub color: Option<String>,
 
     #[serde(rename = "breed")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub breed: Option<String>,
 
@@ -2428,11 +2464,12 @@ impl Dog {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "$special[model.name]")]
 pub struct DollarSpecialLeftSquareBracketModelNameRightSquareBracket {
     #[serde(rename = "$special[property.name]")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub dollar_special_left_square_bracket_property_name_right_square_bracket: Option<i64>,
 
@@ -2599,18 +2636,27 @@ impl DollarSpecialLeftSquareBracketModelNameRightSquareBracket {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct EnumArrays {
     #[serde(rename = "just_symbol")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub just_symbol: Option<models::EnumArraysJustSymbol>,
 
     #[serde(rename = "array_enum")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_enum: Option<Vec<models::EnumArraysArrayEnumInner>>,
 
     #[serde(rename = "array_array_enum")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub array_array_enum: Option<Vec<Vec<models::EnumArraysArrayArrayEnumInnerInner>>>,
 
@@ -2788,6 +2834,7 @@ impl EnumArrays {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumArraysArrayArrayEnumInnerInner {
     #[serde(rename = "Cat")]
@@ -2910,6 +2957,7 @@ impl EnumArraysArrayArrayEnumInnerInner {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumArraysArrayEnumInner {
     #[serde(rename = "fish")]
@@ -3032,6 +3080,7 @@ impl EnumArraysArrayEnumInner {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumArraysJustSymbol {
     #[serde(rename = ">=")]
@@ -3154,6 +3203,7 @@ impl EnumArraysJustSymbol {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumClass {
     #[serde(rename = "_abc")]
@@ -3274,25 +3324,39 @@ impl EnumClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct EnumTest {
     #[serde(rename = "enum_string")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub enum_string: Option<models::EnumTestEnumString>,
 
     #[serde(rename = "enum_string_required")]
+
+    #[cfg_attr(feature = "validate", validate)]
     pub enum_string_required: models::EnumTestEnumString,
 
     #[serde(rename = "enum_integer")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub enum_integer: Option<models::EnumTestEnumInteger>,
 
     #[serde(rename = "enum_number")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub enum_number: Option<models::TestEnumParametersEnumQueryDoubleParameter>,
 
     #[serde(rename = "outerEnum")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub outer_enum: Option<models::OuterEnum>,
 
@@ -3484,6 +3548,7 @@ impl EnumTest {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumTestEnumInteger {
     #[serde(rename = "1")]
@@ -3606,6 +3671,7 @@ impl EnumTestEnumInteger {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum EnumTestEnumString {
     #[serde(rename = "UPPER")]
@@ -3732,6 +3798,7 @@ impl EnumTestEnumString {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum FindPetsByStatusStatusParameterInner {
     #[serde(rename = "available")]
@@ -3852,79 +3919,105 @@ impl FindPetsByStatusStatusParameterInner {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct FormatTest {
     #[serde(rename = "integer")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
             range(min = 10u8, max = 100u8),
-        )]
+        ))]
+    #[cfg_attr(feature = "validate", validate(minimum = 10u8))]
+    #[cfg_attr(feature = "validate", validate(maximum = 100u8))]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub integer: Option<u8>,
 
     #[serde(rename = "int32")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
             range(min = 20u32, max = 200u32),
-        )]
+        ))]
+    #[cfg_attr(feature = "validate", validate(minimum = 20u32))]
+    #[cfg_attr(feature = "validate", validate(maximum = 200u32))]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub int32: Option<u32>,
 
     #[serde(rename = "int64")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub int64: Option<i64>,
 
     #[serde(rename = "number")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
             range(min = 32.1f64, max = 543.2f64),
-        )]
+        ))]
+    #[cfg_attr(feature = "validate", validate(minimum = 32.1f64))]
+    #[cfg_attr(feature = "validate", validate(maximum = 543.2f64))]
+
     pub number: f64,
 
     #[serde(rename = "float")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
             range(min = 54.3f32, max = 987.6f32),
-        )]
+        ))]
+    #[cfg_attr(feature = "validate", validate(minimum = 54.3f32))]
+    #[cfg_attr(feature = "validate", validate(maximum = 987.6f32))]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub float: Option<f32>,
 
     #[serde(rename = "double")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
             range(min = 67.8f64, max = 123.4f64),
-        )]
+        ))]
+    #[cfg_attr(feature = "validate", validate(minimum = 67.8f64))]
+    #[cfg_attr(feature = "validate", validate(maximum = 123.4f64))]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub double: Option<f64>,
 
     #[serde(rename = "string")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
            regex(path = *RE_FORMATTEST_STRING),
-        )]
+        ))]
+    #[cfg_attr(feature = "validate", validate(pattern = r"/[a-z]/i"))]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub string: Option<String>,
 
     #[serde(rename = "byte")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
            custom(function = "validate_byte_formattest_byte")
-        )]
+        ))]
+
     pub byte: swagger::ByteArray,
 
     #[serde(rename = "binary")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub binary: Option<swagger::ByteArray>,
 
     #[serde(rename = "date")]
+
     pub date: chrono::naive::NaiveDate,
 
     #[serde(rename = "dateTime")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub date_time: Option<chrono::DateTime::<chrono::Utc>>,
 
     #[serde(rename = "uuid")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub uuid: Option<uuid::Uuid>,
 
     #[serde(rename = "password")]
-    #[validate(
+    #[cfg_attr(not(feature = "validate"), validate(
             length(min = 10, max = 64),
-        )]
+        ))]
+    #[cfg_attr(feature = "validate", validate(min_length = 10))]
+    #[cfg_attr(feature = "validate", validate(max_length = 64))]
+
     pub password: String,
 
 }
@@ -3935,6 +4028,7 @@ lazy_static::lazy_static! {
 lazy_static::lazy_static! {
     static ref RE_FORMATTEST_BYTE: regex::bytes::Regex = regex::bytes::Regex::new(r"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}&#x3D;&#x3D;|[A-Za-z0-9+/]{3}&#x3D;)?$").unwrap();
 }
+#[cfg(not(feature = "validate"))]
 fn validate_byte_formattest_byte(
     b: &swagger::ByteArray
 ) -> Result<(), validator::ValidationError> {
@@ -4201,14 +4295,16 @@ impl FormatTest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct HasOnlyReadOnly {
     #[serde(rename = "bar")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub bar: Option<String>,
 
     #[serde(rename = "foo")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub foo: Option<String>,
 
@@ -4386,10 +4482,11 @@ impl HasOnlyReadOnly {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct List {
     #[serde(rename = "123-list")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub param_123_list: Option<String>,
 
@@ -4556,18 +4653,25 @@ impl List {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MapTest {
     #[serde(rename = "map_map_of_string")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_map_of_string: Option<std::collections::HashMap<String, std::collections::HashMap<String, String>>>,
 
     #[serde(rename = "map_map_of_enum")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_map_of_enum: Option<std::collections::HashMap<String, std::collections::HashMap<String, models::MapTestMapMapOfEnumValueValue>>>,
 
     #[serde(rename = "map_of_enum_string")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub map_of_enum_string: Option<std::collections::HashMap<String, models::MapTestMapMapOfEnumValueValue>>,
 
@@ -4744,6 +4848,7 @@ impl MapTest {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum MapTestMapMapOfEnumValueValue {
     #[serde(rename = "UPPER")]
@@ -4860,18 +4965,23 @@ impl MapTestMapMapOfEnumValueValue {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct MixedPropertiesAndAdditionalPropertiesClass {
     #[serde(rename = "uuid")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub uuid: Option<uuid::Uuid>,
 
     #[serde(rename = "dateTime")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub date_time: Option<chrono::DateTime::<chrono::Utc>>,
 
     #[serde(rename = "map")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub map: Option<std::collections::HashMap<String, models::Animal>>,
 
@@ -5045,15 +5155,17 @@ impl MixedPropertiesAndAdditionalPropertiesClass {
 }
 
 /// Model for testing model name starting with number
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "Name")]
 pub struct Model200Response {
     #[serde(rename = "name")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<i32>,
 
     #[serde(rename = "class")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub class: Option<String>,
 
@@ -5232,22 +5344,26 @@ impl Model200Response {
 }
 
 /// Model for testing model name same as property name
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "Name")]
 pub struct Name {
     #[serde(rename = "name")]
+
     pub name: i32,
 
     #[serde(rename = "snake_case")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub snake_case: Option<i32>,
 
     #[serde(rename = "property")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub property: Option<String>,
 
     #[serde(rename = "123Number")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub param_123_number: Option<i32>,
 
@@ -5443,10 +5559,11 @@ impl Name {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct NumberOnly {
     #[serde(rename = "JustNumber")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub just_number: Option<f64>,
 
@@ -5613,10 +5730,13 @@ impl NumberOnly {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectContainingObjectWithOnlyAdditionalProperties {
     #[serde(rename = "inner")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner: Option<models::ObjectWithOnlyAdditionalProperties>,
 
@@ -5779,8 +5899,11 @@ impl ObjectContainingObjectWithOnlyAdditionalProperties {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct ObjectWithOnlyAdditionalProperties(std::collections::HashMap<String, String>);
+pub struct ObjectWithOnlyAdditionalProperties(
+    std::collections::HashMap<String, String>
+);
 
 impl std::convert::From<std::collections::HashMap<String, String>> for ObjectWithOnlyAdditionalProperties {
     fn from(x: std::collections::HashMap<String, String>) -> Self {
@@ -5915,31 +6038,39 @@ impl ObjectWithOnlyAdditionalProperties {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "Order")]
 pub struct Order {
     #[serde(rename = "id")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "petId")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub pet_id: Option<i64>,
 
     #[serde(rename = "quantity")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub quantity: Option<i32>,
 
     #[serde(rename = "shipDate")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub ship_date: Option<chrono::DateTime::<chrono::Utc>>,
 
     #[serde(rename = "status")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<models::OrderStatus>,
 
     #[serde(rename = "complete")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub complete: Option<bool>,
 
@@ -6158,6 +6289,7 @@ impl Order {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum OrderStatus {
     #[serde(rename = "placed")]
@@ -6279,8 +6411,11 @@ impl OrderStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct OuterBoolean(bool);
+pub struct OuterBoolean(
+    bool
+);
 
 impl std::convert::From<bool> for OuterBoolean {
     fn from(x: bool) -> Self {
@@ -6417,18 +6552,21 @@ impl OuterBoolean {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct OuterComposite {
     #[serde(rename = "my_number")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub my_number: Option<f64>,
 
     #[serde(rename = "my_string")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub my_string: Option<String>,
 
     #[serde(rename = "my_boolean")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub my_boolean: Option<bool>,
 
@@ -6623,6 +6761,7 @@ impl OuterComposite {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum OuterEnum {
     #[serde(rename = "placed")]
@@ -6744,8 +6883,11 @@ impl OuterEnum {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct OuterNumber(f64);
+pub struct OuterNumber(
+    f64
+);
 
 impl std::convert::From<f64> for OuterNumber {
     fn from(x: f64) -> Self {
@@ -6883,8 +7025,11 @@ impl OuterNumber {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct OuterString(String);
+pub struct OuterString(
+    String
+);
 
 impl std::convert::From<String> for OuterString {
     fn from(x: String) -> Self {
@@ -7011,29 +7156,41 @@ impl OuterString {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "Pet")]
 pub struct Pet {
     #[serde(rename = "id")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "category")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub category: Option<models::Category>,
 
     #[serde(rename = "name")]
+
     pub name: String,
 
     #[serde(rename = "photoUrls")]
+
     pub photo_urls: Vec<String>,
 
     #[serde(rename = "tags")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub tags: Option<Vec<models::Tag>>,
 
     #[serde(rename = "status")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub status: Option<models::PetStatus>,
 
@@ -7237,6 +7394,7 @@ impl Pet {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum PetStatus {
     #[serde(rename = "available")]
@@ -7357,14 +7515,16 @@ impl PetStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ReadOnlyFirst {
     #[serde(rename = "bar")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub bar: Option<String>,
 
     #[serde(rename = "baz")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub baz: Option<String>,
 
@@ -7543,11 +7703,12 @@ impl ReadOnlyFirst {
 }
 
 /// Model for testing reserved words
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "Return")]
 pub struct Return {
     #[serde(rename = "return")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub r#return: Option<i32>,
 
@@ -7714,15 +7875,17 @@ impl Return {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "Tag")]
 pub struct Tag {
     #[serde(rename = "id")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "name")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub name: Option<String>,
 
@@ -7906,6 +8069,7 @@ impl Tag {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum TestEnumParametersEnumHeaderStringArrayParameterInner {
     #[serde(rename = ">")]
@@ -8028,6 +8192,7 @@ impl TestEnumParametersEnumHeaderStringArrayParameterInner {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum TestEnumParametersEnumHeaderStringParameter {
     #[serde(rename = "_abc")]
@@ -8154,6 +8319,7 @@ impl TestEnumParametersEnumHeaderStringParameter {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum TestEnumParametersEnumQueryDoubleParameter {
     #[serde(rename = "1.1")]
@@ -8276,6 +8442,7 @@ impl TestEnumParametersEnumQueryDoubleParameter {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum TestEnumParametersEnumQueryIntegerParameter {
     #[serde(rename = "1")]
@@ -8399,6 +8566,7 @@ impl TestEnumParametersEnumQueryIntegerParameter {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Hash)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk_enum_derive::LabelledGenericEnum))]
 pub enum TestEnumParametersRequestEnumFormString {
     #[serde(rename = "_abc")]
@@ -8519,40 +8687,48 @@ impl TestEnumParametersRequestEnumFormString {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 #[serde(rename = "User")]
 pub struct User {
     #[serde(rename = "id")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub id: Option<i64>,
 
     #[serde(rename = "username")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub username: Option<String>,
 
     #[serde(rename = "firstName")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub first_name: Option<String>,
 
     #[serde(rename = "lastName")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub last_name: Option<String>,
 
     #[serde(rename = "email")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub email: Option<String>,
 
     #[serde(rename = "password")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
 
     #[serde(rename = "phone")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub phone: Option<String>,
 
     /// User Status
     #[serde(rename = "userStatus")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub user_status: Option<i32>,
 

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/Cargo.toml
@@ -22,6 +22,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -46,6 +47,8 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/README.md
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/README.md
@@ -113,6 +113,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/src/models.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/src/models.rs
@@ -1,7 +1,9 @@
 #![allow(unused_qualifications)]
-
+#[cfg(not(feature = "validate"))]
 use validator::Validate;
 
 use crate::models;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::header;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/src/server/mod.rs
@@ -4,6 +4,8 @@ use http_body_util::{combinators::BoxBody, Full};
 use hyper::{body::{Body, Incoming}, HeaderMap, Request, Response, StatusCode};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 #[allow(unused_imports)]
 use std::convert::{TryFrom, TryInto};
 use std::{convert::Infallible, error::Error};
@@ -48,6 +50,7 @@ where
 {
     api_impl: T,
     marker: PhantomData<C>,
+    validation: bool
 }
 
 impl<T, C> MakeService<T, C>
@@ -58,8 +61,15 @@ where
     pub fn new(api_impl: T) -> Self {
         MakeService {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation: false
         }
+    }
+
+    // Turn on/off validation for the service being made.
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation;
     }
 }
 
@@ -72,6 +82,7 @@ where
         Self {
             api_impl: self.api_impl.clone(),
             marker: PhantomData,
+            validation: self.validation
         }
     }
 }
@@ -86,7 +97,7 @@ where
     type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
     fn call(&self, target: Target) -> Self::Future {
-        let service = Service::new(self.api_impl.clone());
+        let service = Service::new(self.api_impl.clone(), self.validation);
 
         future::ok(service)
     }
@@ -100,24 +111,57 @@ fn method_not_allowed() -> Result<Response<BoxBody<Bytes, Infallible>>, crate::S
     )
 }
 
+#[allow(unused_macros)]
+#[cfg(not(feature = "validate"))]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => ();
+}
+
+#[allow(unused_macros)]
+#[cfg(feature = "validate")]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => {
+        let $parameter = if $validation {
+            match $parameter.validate() {
+            Ok(()) => $parameter,
+            Err(e) => return Ok(Response::builder()
+                                    .status(StatusCode::BAD_REQUEST)
+                                    .header(CONTENT_TYPE, mime::TEXT_PLAIN.as_ref())
+                                    .body(BoxBody::new(format!("Invalid value in body parameter {}: {}", $base_name, e)))
+                                    .expect(&format!("Unable to create Bad Request response for invalid value in body parameter {}", $base_name))),
+            }
+        } else {
+            $parameter
+        };
+    }
+}
+
 pub struct Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString> + Has<Option<Authorization>> + Send + Sync + 'static
 {
     api_impl: T,
     marker: PhantomData<C>,
+    // Enable regex pattern validation of received JSON models
+    validation: bool,
 }
 
 impl<T, C> Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString> + Has<Option<Authorization>> + Send + Sync + 'static
 {
-    pub fn new(api_impl: T) -> Self {
+    pub fn new(api_impl: T, validation: bool) -> Self {
         Service {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation,
         }
     }
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation
+    }
+
 }
 
 impl<T, C> Clone for Service<T, C> where
@@ -128,6 +172,7 @@ impl<T, C> Clone for Service<T, C> where
         Service {
             api_impl: self.api_impl.clone(),
             marker: self.marker,
+            validation: self.validation,
         }
     }
 }
@@ -156,6 +201,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         async fn run<T, C, ReqBody>(
             mut api_impl: T,
             req: (Request<ReqBody>, C),
+            validation: bool,
         ) -> Result<Response<BoxBody<Bytes, Infallible>>, crate::ServiceError>
         where
             T: Api<C> + Clone + Send + 'static,
@@ -220,6 +266,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         Box::pin(run(
             self.api_impl.clone(),
             req,
+            self.validation
         ))
     }
 }

--- a/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
+++ b/samples/server/petstore/rust-server/output/rust-server-test/.openapi-generator/FILES
@@ -12,6 +12,8 @@ docs/DummyPutRequest.md
 docs/GetYamlResponse.md
 docs/ObjectOfObjects.md
 docs/ObjectOfObjectsInner.md
+docs/UnnamedAllofUnderProperties.md
+docs/UnnamedReference.md
 docs/default_api.md
 examples/ca.pem
 examples/client/client_auth.rs

--- a/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/Cargo.toml
@@ -22,6 +22,7 @@ cli = [
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]
 
 mock = ["mockall"]
+validate = ["regex", "serde_valid", "swagger/serdevalid"]
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "ios"))'.dependencies]
 native-tls = { version = "0.2", optional = true }
@@ -46,6 +47,8 @@ mockall = { version = "0.13.1", optional = true }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_valid = { version = "0.16", optional = true }
+
 validator = { version = "0.20", features = ["derive"] }
 
 # Crates included if required by the API definition

--- a/samples/server/petstore/rust-server/output/rust-server-test/README.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/README.md
@@ -119,6 +119,9 @@ The generated library has a few optional features that can be activated through 
     * This defaults to disabled and creates extra derives on models to allow "transmogrification" between objects of structurally similar types.
 * `cli`
     * This defaults to disabled and is required for building the included CLI tool.
+* `validate`
+    * This defaults to disabled and allows JSON Schema validation of received data using `MakeService::set_validation` or `Service::set_validation`.
+    * Note, enabling validation will have a performance penalty, especially if the API heavily uses regex based checks.
 
 See https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section for how to use features in your `Cargo.toml`.
 
@@ -149,6 +152,8 @@ Method | HTTP request | Description
  - [GetYamlResponse](docs/GetYamlResponse.md)
  - [ObjectOfObjects](docs/ObjectOfObjects.md)
  - [ObjectOfObjectsInner](docs/ObjectOfObjectsInner.md)
+ - [UnnamedAllofUnderProperties](docs/UnnamedAllofUnderProperties.md)
+ - [UnnamedReference](docs/UnnamedReference.md)
 
 
 ## Documentation For Authorization

--- a/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
+++ b/samples/server/petstore/rust-server/output/rust-server-test/api/openapi.yaml
@@ -183,6 +183,21 @@ components:
           description: Inner string
           type: string
       type: object
+    unnamed_allof_under_properties:
+      description: Model for testing allOf references inside properties
+      properties:
+        name:
+          allOf:
+          - $ref: "#/components/schemas/unnamed_reference"
+          type: object
+      type: object
+    unnamed_reference:
+      exclusiveMaximum: true
+      exclusiveMinimum: true
+      format: int32
+      maximum: 30
+      minimum: 5
+      type: integer
     dummyPut_request:
       properties:
         id:

--- a/samples/server/petstore/rust-server/output/rust-server-test/docs/UnnamedAllofUnderProperties.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/docs/UnnamedAllofUnderProperties.md
@@ -1,0 +1,10 @@
+# UnnamedAllofUnderProperties
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | **u32** |  | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/rust-server-test/docs/UnnamedReference.md
+++ b/samples/server/petstore/rust-server/output/rust-server-test/docs/UnnamedReference.md
@@ -1,0 +1,9 @@
+# UnnamedReference
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/models.rs
@@ -1,21 +1,25 @@
 #![allow(unused_qualifications)]
-
+#[cfg(not(feature = "validate"))]
 use validator::Validate;
 
 use crate::models;
 #[cfg(any(feature = "client", feature = "server"))]
 use crate::header;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ANullableContainer {
     #[serde(rename = "NullableThing")]
+
     #[serde(deserialize_with = "swagger::nullable_format::deserialize_optional_nullable")]
     #[serde(default = "swagger::nullable_format::default_optional_nullable")]
     #[serde(skip_serializing_if="Option::is_none")]
     pub nullable_thing: Option<swagger::Nullable<String>>,
 
     #[serde(rename = "RequiredNullableThing")]
+
     pub required_nullable_thing: swagger::Nullable<String>,
 
 }
@@ -179,8 +183,11 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 
 /// An additionalPropertiesObject
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "validate", derive(Validate))]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AdditionalPropertiesObject(std::collections::HashMap<String, String>);
+pub struct AdditionalPropertiesObject(
+    std::collections::HashMap<String, String>
+);
 
 impl std::convert::From<std::collections::HashMap<String, String>> for AdditionalPropertiesObject {
     fn from(x: std::collections::HashMap<String, String>) -> Self {
@@ -306,14 +313,16 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AllOfObject {
     #[serde(rename = "sampleBaseProperty")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub sample_base_property: Option<String>,
 
     #[serde(rename = "sampleProperty")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub sample_property: Option<String>,
 
@@ -482,10 +491,11 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct BaseAllOf {
     #[serde(rename = "sampleBaseProperty")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub sample_base_property: Option<String>,
 
@@ -643,13 +653,15 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct DummyPutRequest {
     #[serde(rename = "id")]
+
     pub id: String,
 
     #[serde(rename = "password")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub password: Option<String>,
 
@@ -815,11 +827,12 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 }
 
 /// structured response
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct GetYamlResponse {
     /// Inner string
     #[serde(rename = "value")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub value: Option<String>,
 
@@ -978,10 +991,13 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 }
 
 /// An object of objects
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectOfObjects {
     #[serde(rename = "inner")]
+
+    #[cfg_attr(feature = "validate", validate)]
+    #[cfg_attr(feature = "validate", validate)]
     #[serde(skip_serializing_if="Option::is_none")]
     pub inner: Option<models::ObjectOfObjectsInner>,
 
@@ -1134,13 +1150,15 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct ObjectOfObjectsInner {
     #[serde(rename = "required_thing")]
+
     pub required_thing: String,
 
     #[serde(rename = "optional_thing")]
+
     #[serde(skip_serializing_if="Option::is_none")]
     pub optional_thing: Option<i32>,
 
@@ -1294,6 +1312,309 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
                             std::result::Result::Ok(value) => std::result::Result::Ok(value),
                             std::result::Result::Err(err) => std::result::Result::Err(
                                 format!("Unable to convert header value '{hdr_value}' into ObjectOfObjectsInner - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}
+
+/// Model for testing allOf references inside properties
+#[derive(Debug, Clone, PartialEq, Validate, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct UnnamedAllofUnderProperties {
+    #[serde(rename = "name")]
+    #[cfg_attr(not(feature = "validate"), validate(
+            range(min = 5u32, max = 30u32),
+        ))]
+    #[cfg_attr(feature = "validate", validate(exclusive_minimum = 5u32))]
+    #[cfg_attr(feature = "validate", validate(exclusive_maximum = 30u32))]
+
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub name: Option<u32>,
+
+}
+
+
+impl UnnamedAllofUnderProperties {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> UnnamedAllofUnderProperties {
+        UnnamedAllofUnderProperties {
+            name: None,
+        }
+    }
+}
+
+/// Converts the UnnamedAllofUnderProperties value to the Query Parameters representation (style=form, explode=false)
+/// specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for UnnamedAllofUnderProperties {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            self.name.as_ref().map(|name| {
+                [
+                    "name".to_string(),
+                    name.to_string(),
+                ].join(",")
+            }),
+        ];
+
+        write!(f, "{}", params.into_iter().flatten().collect::<Vec<_>>().join(","))
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a UnnamedAllofUnderProperties value
+/// as specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for UnnamedAllofUnderProperties {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub name: Vec<u32>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => return std::result::Result::Err("Missing value while parsing UnnamedAllofUnderProperties".to_string())
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "name" => intermediate_rep.name.push(<u32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing UnnamedAllofUnderProperties".to_string())
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(UnnamedAllofUnderProperties {
+            name: intermediate_rep.name.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<UnnamedAllofUnderProperties> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<UnnamedAllofUnderProperties>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<UnnamedAllofUnderProperties>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UnnamedAllofUnderProperties - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<UnnamedAllofUnderProperties> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <UnnamedAllofUnderProperties as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into UnnamedAllofUnderProperties - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<UnnamedAllofUnderProperties>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<UnnamedAllofUnderProperties>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}",))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<UnnamedAllofUnderProperties>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<UnnamedAllofUnderProperties> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <UnnamedAllofUnderProperties as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into UnnamedAllofUnderProperties - {err}"))
+                        }
+                    })
+                }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;
+
+                std::result::Result::Ok(header::IntoHeaderValue(hdr_values))
+            },
+            std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to parse header: {hdr_values:?} as a string - {e}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "validate", derive(Validate))]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct UnnamedReference(
+    #[cfg_attr(feature = "validate", validate(exclusive_minimum = 5i32))]
+    #[cfg_attr(feature = "validate", validate(exclusive_maximum = 30i32))]
+    i32
+);
+
+impl std::convert::From<i32> for UnnamedReference {
+    fn from(x: i32) -> Self {
+        UnnamedReference(x)
+    }
+}
+
+impl std::convert::From<UnnamedReference> for i32 {
+    fn from(x: UnnamedReference) -> Self {
+        x.0
+    }
+}
+
+impl std::ops::Deref for UnnamedReference {
+    type Target = i32;
+    fn deref(&self) -> &i32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for UnnamedReference {
+    fn deref_mut(&mut self) -> &mut i32 {
+        &mut self.0
+    }
+}
+
+/// Converts the UnnamedReference value to the Query Parameters representation (style=form, explode=false)
+/// specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for UnnamedReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a UnnamedReference value
+/// as specified in <https://swagger.io/docs/specification/serialization/>
+/// Should be implemented in a serde deserializer
+impl ::std::str::FromStr for UnnamedReference {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match std::str::FromStr::from_str(s) {
+             std::result::Result::Ok(r) => std::result::Result::Ok(UnnamedReference(r)),
+             std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {s} to UnnamedReference: {e:?}")),
+        }
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<UnnamedReference> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<UnnamedReference>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_value: header::IntoHeaderValue<UnnamedReference>) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+             std::result::Result::Ok(value) => std::result::Result::Ok(value),
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Invalid header value for UnnamedReference - value: {hdr_value} is invalid {e}"))
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<UnnamedReference> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+             std::result::Result::Ok(value) => {
+                    match <UnnamedReference as std::str::FromStr>::from_str(value) {
+                        std::result::Result::Ok(value) => std::result::Result::Ok(header::IntoHeaderValue(value)),
+                        std::result::Result::Err(err) => std::result::Result::Err(
+                            format!("Unable to convert header value '{value}' into UnnamedReference - {err}"))
+                    }
+             },
+             std::result::Result::Err(e) => std::result::Result::Err(
+                 format!("Unable to convert header: {hdr_value:?} to string: {e}"))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<Vec<UnnamedReference>>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(hdr_values: header::IntoHeaderValue<Vec<UnnamedReference>>) -> std::result::Result<Self, Self::Error> {
+        let hdr_values : Vec<String> = hdr_values.0.into_iter().map(|hdr_value| {
+            hdr_value.to_string()
+        }).collect();
+
+        match hyper::header::HeaderValue::from_str(&hdr_values.join(", ")) {
+           std::result::Result::Ok(hdr_value) => std::result::Result::Ok(hdr_value),
+           std::result::Result::Err(e) => std::result::Result::Err(format!("Unable to convert {hdr_values:?} into a header - {e}",))
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Vec<UnnamedReference>> {
+    type Error = String;
+
+    fn try_from(hdr_values: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_values.to_str() {
+            std::result::Result::Ok(hdr_values) => {
+                let hdr_values : std::vec::Vec<UnnamedReference> = hdr_values
+                .split(',')
+                .filter_map(|hdr_value| match hdr_value.trim() {
+                    "" => std::option::Option::None,
+                    hdr_value => std::option::Option::Some({
+                        match <UnnamedReference as std::str::FromStr>::from_str(hdr_value) {
+                            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+                            std::result::Result::Err(err) => std::result::Result::Err(
+                                format!("Unable to convert header value '{hdr_value}' into UnnamedReference - {err}"))
                         }
                     })
                 }).collect::<std::result::Result<std::vec::Vec<_>, String>>()?;

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -4,6 +4,8 @@ use http_body_util::{combinators::BoxBody, Full};
 use hyper::{body::{Body, Incoming}, HeaderMap, Request, Response, StatusCode};
 use hyper::header::{HeaderName, HeaderValue, CONTENT_TYPE};
 use log::warn;
+#[cfg(feature = "validate")]
+use serde_valid::Validate;
 #[allow(unused_imports)]
 use std::convert::{TryFrom, TryInto};
 use std::{convert::Infallible, error::Error};
@@ -70,6 +72,7 @@ where
 {
     api_impl: T,
     marker: PhantomData<C>,
+    validation: bool
 }
 
 impl<T, C> MakeService<T, C>
@@ -80,8 +83,15 @@ where
     pub fn new(api_impl: T) -> Self {
         MakeService {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation: false
         }
+    }
+
+    // Turn on/off validation for the service being made.
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation;
     }
 }
 
@@ -94,6 +104,7 @@ where
         Self {
             api_impl: self.api_impl.clone(),
             marker: PhantomData,
+            validation: self.validation
         }
     }
 }
@@ -108,7 +119,7 @@ where
     type Future = future::Ready<Result<Self::Response, Self::Error>>;
 
     fn call(&self, target: Target) -> Self::Future {
-        let service = Service::new(self.api_impl.clone());
+        let service = Service::new(self.api_impl.clone(), self.validation);
 
         future::ok(service)
     }
@@ -122,24 +133,57 @@ fn method_not_allowed() -> Result<Response<BoxBody<Bytes, Infallible>>, crate::S
     )
 }
 
+#[allow(unused_macros)]
+#[cfg(not(feature = "validate"))]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => ();
+}
+
+#[allow(unused_macros)]
+#[cfg(feature = "validate")]
+macro_rules! run_validation {
+    ($parameter:tt, $base_name:tt, $validation:tt) => {
+        let $parameter = if $validation {
+            match $parameter.validate() {
+            Ok(()) => $parameter,
+            Err(e) => return Ok(Response::builder()
+                                    .status(StatusCode::BAD_REQUEST)
+                                    .header(CONTENT_TYPE, mime::TEXT_PLAIN.as_ref())
+                                    .body(BoxBody::new(format!("Invalid value in body parameter {}: {}", $base_name, e)))
+                                    .expect(&format!("Unable to create Bad Request response for invalid value in body parameter {}", $base_name))),
+            }
+        } else {
+            $parameter
+        };
+    }
+}
+
 pub struct Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString>  + Send + Sync + 'static
 {
     api_impl: T,
     marker: PhantomData<C>,
+    // Enable regex pattern validation of received JSON models
+    validation: bool,
 }
 
 impl<T, C> Service<T, C> where
     T: Api<C> + Clone + Send + 'static,
     C: Has<XSpanIdString>  + Send + Sync + 'static
 {
-    pub fn new(api_impl: T) -> Self {
+    pub fn new(api_impl: T, validation: bool) -> Self {
         Service {
             api_impl,
-            marker: PhantomData
+            marker: PhantomData,
+            validation,
         }
     }
+    #[cfg(feature = "validate")]
+    pub fn set_validation(&mut self, validation: bool) {
+        self.validation = validation
+    }
+
 }
 
 impl<T, C> Clone for Service<T, C> where
@@ -150,6 +194,7 @@ impl<T, C> Clone for Service<T, C> where
         Service {
             api_impl: self.api_impl.clone(),
             marker: self.marker,
+            validation: self.validation,
         }
     }
 }
@@ -178,6 +223,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         async fn run<T, C, ReqBody>(
             mut api_impl: T,
             req: (Request<ReqBody>, C),
+            validation: bool,
         ) -> Result<Response<BoxBody<Bytes, Infallible>>, crate::ServiceError>
         where
             T: Api<C> + Clone + Send + 'static,
@@ -292,6 +338,8 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
                                                         .body(BoxBody::new("Missing required body parameter nested_response".to_string()))
                                                         .expect("Unable to create Bad Request response for missing body parameter nested_response")),
                                 };
+        #[cfg(not(feature = "validate"))]
+                                run_validation!(param_nested_response, "nested_response", validation);
 
 
                                 let result = api_impl.dummy_put(
@@ -668,6 +716,7 @@ impl<T, C, ReqBody> hyper::service::Service<(Request<ReqBody>, C)> for Service<T
         Box::pin(run(
             self.api_impl.clone(),
             req,
+            self.validation
         ))
     }
 }


### PR DESCRIPTION
[Rust-Server] Add serde_valid support alongside existing validator validation

Adds support for the serde_valid validation crate to Rust server generator while maintaining full backward compatibility with the existing validator crate. Controlled by the validate Cargo feature flag.

* validate - When enabled, uses serde_valid::Validate instead of validator::Validate
* Default behavior (no flag): Uses validator::Validate (existing behavior)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package || exit
  ./bin/generate-samples.sh ./bin/configs/*.yaml || exit
  ./bin/utils/export_docs_generators.sh || exit
  ``` 
  (For Windows users, please run the script in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming `7.x.0` minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR solves a reported issue, reference it using [GitHub's linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) (e.g., having `"fixes #123"` present in the PR description)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
